### PR TITLE
fix: align Add Lab Users select dropdowns with their trigger width

### DIFF
--- a/packages/front-end/src/app/components/EGAddLabUsersModule.vue
+++ b/packages/front-end/src/app/components/EGAddLabUsersModule.vue
@@ -130,7 +130,7 @@
 </script>
 
 <template>
-  <div :aria-busy="uiStore.anyRequestPending(['getLabUsers', 'addUsersToLab'])">
+  <div class="add-lab-users" :aria-busy="uiStore.anyRequestPending(['getLabUsers', 'addUsersToLab'])">
     <EGCard :padding="4">
       <p :id="addUsersStatusId" class="sr-only" aria-live="polite" aria-atomic="true">{{ addUsersStatusMessage }}</p>
       <div class="flex flex-col gap-3">
@@ -155,7 +155,6 @@
             :ui="{
               base: 'h-[52px]',
             }"
-            :popper="{ strategy: 'fixed' }"
             :aria-label="`Select users to add to ${labName}`"
           >
             <template #option="{ option: user }">
@@ -192,7 +191,6 @@
               class="w-44"
               size="xl"
               :disabled="uiStore.anyRequestPending(['getLabUsers', 'addUsersToLab'])"
-              :popper="{ strategy: 'fixed' }"
               aria-label="Role for added users"
             />
           </div>
@@ -222,3 +220,13 @@
     </EGCard>
   </div>
 </template>
+
+<style scoped lang="scss">
+  .add-lab-users {
+    // Nuxt UI's SelectMenu options list picks up a stray left margin from Headless UI's
+    // default list styling, leaving the dropdown narrower than its trigger on one side.
+    :deep([role='listbox']) {
+      margin-left: 0;
+    }
+  }
+</style>


### PR DESCRIPTION
## Title*
fix: align Add Lab Users select dropdowns with their trigger width

## Type of Change*
- [x] Bug fix

## Description
The "Select User" and role dropdowns in the Add Lab Users modal opened options panels that didn't match their trigger's width — the panel would render far wider than (or misaligned relative to) the input it belongs to.

Two separate issues were stacked here:
1. `:popper="{ strategy: 'fixed' }"` on both `USelectMenu`s (added when this modal was first wrapped in a `UModal`, to avoid the dropdown being clipped by the modal). Once that commit also changed the layout to a vertical, full-width stack, this override was no longer needed — under `strategy: 'fixed'`, the dropdown's `w-full` resolves against the viewport instead of the trigger, which is what caused the panel to blow out to full page width. Removed; Nuxt UI's default `absolute` strategy correctly sizes the dropdown against its trigger's own `relative` wrapper, same as every other `USelectMenu` in this codebase.
2. Even after removing that, the dropdown was still off by a consistent margin on one side. Traced to a stray `margin-left` on Headless UI's own options list (`<ul role="listbox">`), unrelated to popper positioning. Reset via a scoped `:deep([role='listbox'])` override — the same pattern already used in `EGUserAccessPanel.vue` for patching Nuxt UI internals.

## Testing*
- Verified with a fresh Playwright session (not relying on dev-server HMR) against the local dev server: both the user picker and role picker dropdowns now render with the exact same `x`/`width` as their trigger buttons, with `margin-left: 0`.
- `pnpm test` passed for `front-end` and `back-end`.

## Impact
Pure CSS/markup fix scoped to `EGAddLabUsersModule.vue`. No API, schema, or behavioral changes.

## Additional Information
None.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary. (No new test needed — this is a visual/CSS-only fix with no new logic branches.)
- [ ] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.