### PR TITLE
feat: added my runs only switch to recent runs in dashboard

### DIFF
--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/create-laboratory-run.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/create-laboratory-run.lambda.ts
@@ -83,7 +83,9 @@ export const handler: Handler = async (
 ): Promise<APIGatewayProxyResult> => {
   console.log('EVENT: \n' + JSON.stringify(event, null, 2));
   try {
-    const currentUserId = event.requestContext.authorizer.claims['cognito:username'];
+    // Prefer platform UserId claim (set by pre-token-generation) so run ownership matches DynamoDB User records.
+    const currentUserId =
+      event.requestContext.authorizer.claims.UserId || event.requestContext.authorizer.claims['cognito:username'];
     const currentUserEmail = event.requestContext.authorizer.claims.email;
     // Post Request Body
     const request: AddLaboratoryRun = event.isBase64Encoded ? JSON.parse(atob(event.body!)) : JSON.parse(event.body!);

--- a/packages/back-end/src/app/utils/rest-api-utils.ts
+++ b/packages/back-end/src/app/utils/rest-api-utils.ts
@@ -151,7 +151,8 @@ export function getFilterResults<T>(results: T[], filters: [string, string][]): 
   const filterResults = results.filter((r: T) => {
     // https://stackoverflow.com/a/3561711 - this escape function is the same as this answer EXCEPT the * is removed
     const regexEscapedInput = filterVal.replace(/[/\-\\^$+?.()|[\]{}]/g, '\\$&');
-    const regex = new RegExp('^' + regexEscapedInput.replace(/\*/g, '.*') + '$');
+    // Case-insensitive so Owner email filters match regardless of claim casing
+    const regex = new RegExp('^' + regexEscapedInput.replace(/\*/g, '.*') + '$', 'i');
     const value = (r as Record<string, unknown>)[filterKey];
     return regex.test(String(value ?? ''));
   });

--- a/packages/front-end/src/app/components/EGDashboard.vue
+++ b/packages/front-end/src/app/components/EGDashboard.vue
@@ -5,6 +5,7 @@
   import { Pipeline as SeqeraPipeline } from '@easy-genomics/shared-lib/src/app/types/nf-tower/nextflow-tower-api';
   import { WorkflowListItem as OmicsWorkflow } from '@aws-sdk/client-omics';
   import { useUiStore, useSeqeraPipelinesStore, useOmicsWorkflowsStore } from '@FE/stores';
+  import { isLaboratoryRunOwnedByUser } from '@FE/utils/laboratory-run-ownership';
   import { TableSort } from './EGTable.vue';
 
   const props = defineProps<{
@@ -13,6 +14,7 @@
 
   const { $api } = useNuxtApp();
   const $router = useRouter();
+  const $route = useRoute();
   const labStore = useLabsStore();
   const userStore = useUserStore();
   const uiStore = useUiStore();
@@ -34,7 +36,9 @@
   const recentRunsHeadingId = 'dashboard-recent-runs-heading';
   const favouriteWorkflowsHeadingId = 'dashboard-favourite-workflows-heading';
   const inProgressHeadingId = 'dashboard-in-progress-heading';
+  const recentRunsMyRunsOnlyId = 'dashboard-recent-runs-my-runs-only';
   const highlightedSearchIndex = ref(-1);
+  const recentRunsMyRunsOnly = ref(false);
 
   const IN_PROGRESS_STATUSES = new Set(['SUBMITTED', 'STARTING', 'RUNNING']);
 
@@ -322,8 +326,14 @@
 
   const recentRuns = computed(() => {
     // Match the design: in-progress runs live in the In progress section, not Recent runs.
+    const currentUser = {
+      id: userStore.currentUserDetails.id,
+      email: userStore.currentUserDetails.email,
+    };
+
     return [...allRuns.value]
       .filter((r) => !IN_PROGRESS_STATUSES.has(r.Status))
+      .filter((r) => !recentRunsMyRunsOnly.value || isLaboratoryRunOwnedByUser(r, currentUser))
       .sort((a, b) => {
         const dateA = a.CreatedAt ? new Date(a.CreatedAt).getTime() : 0;
         const dateB = b.CreatedAt ? new Date(b.CreatedAt).getTime() : 0;
@@ -331,6 +341,13 @@
       })
       .slice(0, 5);
   });
+
+  function viewAllRuns() {
+    $router.push({
+      path: `/labs/${props.labId}`,
+      query: { ...$route.query, tab: 'Pipeline Runs' },
+    });
+  }
 
   const recentRunsTableColumns = [
     { key: 'RunName', label: 'Run Name', sortable: true },
@@ -728,7 +745,29 @@
 
     <!-- Recent Runs -->
     <section class="mt-10" :aria-labelledby="recentRunsHeadingId">
-      <EGText :id="recentRunsHeadingId" tag="h2" class="mb-8">Recent Runs</EGText>
+      <div class="mb-8 flex items-center justify-between gap-4">
+        <EGText :id="recentRunsHeadingId" tag="h2" class="mb-0">Recent Runs</EGText>
+        <div class="flex items-center gap-4">
+          <div class="flex items-center gap-2">
+            <UToggle
+              :id="recentRunsMyRunsOnlyId"
+              v-model="recentRunsMyRunsOnly"
+              :aria-labelledby="`${recentRunsMyRunsOnlyId}-label`"
+            />
+            <label :id="`${recentRunsMyRunsOnlyId}-label`" :for="recentRunsMyRunsOnlyId" class="text-body text-sm">
+              My runs only
+            </label>
+          </div>
+          <button
+            type="button"
+            class="text-primary hover:text-primary-dark focus-visible:outline-primary-500 inline-flex items-center gap-1 text-sm font-medium focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
+            @click="viewAllRuns"
+          >
+            View all
+            <UIcon name="i-heroicons-arrow-right" class="h-4 w-4" aria-hidden="true" />
+          </button>
+        </div>
+      </div>
 
       <EGTable
         :row-click-action="viewRunDetails"
@@ -741,7 +780,10 @@
       >
         <template #RunName-data="{ row: run }">
           <div v-if="run.RunName" class="text-body text-sm font-medium">{{ run.RunName }}</div>
-          <div v-if="run.WorkflowName" class="text-muted text-xs font-normal">{{ run.WorkflowName }}</div>
+          <div v-if="run.WorkflowName || run.Owner" class="text-muted text-xs font-normal">
+            <template v-if="run.WorkflowName && run.Owner">{{ run.WorkflowName }} · {{ run.Owner }}</template>
+            <template v-else>{{ run.WorkflowName || run.Owner }}</template>
+          </div>
           <div v-if="run.Description" class="text-muted line-clamp-1 text-xs font-normal">{{ run.Description }}</div>
         </template>
 
@@ -766,7 +808,9 @@
         </template>
 
         <template #empty-state>
-          <div class="text-muted flex h-24 items-center justify-center font-normal">No recent runs</div>
+          <div class="text-muted flex h-24 items-center justify-center font-normal">
+            {{ recentRunsMyRunsOnly ? 'No recent runs initiated by you' : 'No recent runs' }}
+          </div>
         </template>
       </EGTable>
     </section>

--- a/packages/front-end/src/app/components/EGLabView.vue
+++ b/packages/front-end/src/app/components/EGLabView.vue
@@ -20,6 +20,7 @@
   import type { DataCollectionsTab } from '@FE/components/EGDataCollectionsTabBar.vue';
   import { TableSort } from './EGTable.vue';
   import { ensureLabInActiveOrg } from '@FE/utils/ensure-lab-in-active-org';
+  import { isLaboratoryRunOwnedByUser } from '@FE/utils/laboratory-run-ownership';
 
   const props = defineProps<{
     superuser?: boolean;
@@ -235,6 +236,12 @@
     tabIndex.value = 0;
   }
 
+  // Keep tab in sync when navigating via query (e.g. Dashboard "View all" → Pipeline Runs)
+  watch(
+    () => props.initialTab,
+    () => setTabIndex(),
+  );
+
   function handleTabChange(newIndex: number) {
     const fromTab = tabItems.value[tabIndex.value]?.key || '';
     const toTab = tabItems.value[newIndex]?.key || '';
@@ -323,7 +330,7 @@
     return runsTableItems.value.filter((run) => matchesRunSearch(run, runsSearchQuery.value));
   });
 
-  // fetch the runs with BE filtering any time any of the inputs change
+  // fetch the runs any time any of the inputs change; apply "My runs only" client-side
   watchEffect(async () => {
     uiStore.setRequestPending('loadLabRuns');
 
@@ -333,11 +340,19 @@
     // laboratory run polling refresh key
     runsTableRefreshKey.value;
 
-    const filters: any = {};
-    if (runsTableFilterMyRunsOnly.value) filters.UserId = userStore.currentUserDetails.id!;
+    const myRunsOnly = runsTableFilterMyRunsOnly.value;
+    const currentUser = {
+      id: userStore.currentUserDetails.id,
+      email: userStore.currentUserDetails.email,
+    };
 
     try {
-      runsTableItems.value = (await $api.labs.listLabRuns(props.labId, filters))
+      let labRuns = await $api.labs.listLabRuns(props.labId);
+      if (myRunsOnly) {
+        labRuns = labRuns.filter((labRun) => isLaboratoryRunOwnedByUser(labRun, currentUser));
+      }
+
+      runsTableItems.value = labRuns
         .map((labRun) => {
           const lastUpdated = labRun.ModifiedAt ?? labRun.CreatedAt ?? '';
           const searchIndex = [
@@ -930,7 +945,16 @@
           :disabled="useUiStore().anyRequestPending(['loadLabData', 'loadLabRuns'])"
           class="w-[408px]"
         />
-        <UCheckbox label="My runs only" :ui="{ base: 'size-[24px]' }" v-model="runsTableFilterMyRunsOnly" />
+        <div class="flex items-center gap-2">
+          <UToggle
+            id="pipeline-runs-my-runs-only"
+            v-model="runsTableFilterMyRunsOnly"
+            aria-labelledby="pipeline-runs-my-runs-only-label"
+          />
+          <label id="pipeline-runs-my-runs-only-label" for="pipeline-runs-my-runs-only" class="text-body text-sm">
+            My runs only
+          </label>
+        </div>
       </div>
       <p class="text-muted mt-1 text-xs">
         Search by all run fields or use queries like
@@ -1002,7 +1026,13 @@
       </template>
 
       <template #empty-state>
-        <div class="text-muted flex h-24 items-center justify-center font-normal">There are no Runs in your Lab</div>
+        <div class="text-muted flex h-24 items-center justify-center font-normal">
+          {{
+            runsTableFilterMyRunsOnly
+              ? 'There are no runs initiated by you in this Lab'
+              : 'There are no Runs in your Lab'
+          }}
+        </div>
       </template>
     </EGTable>
     <p v-if="runRecordsRetentionNotice" class="text-muted mt-3 max-w-3xl text-xs leading-relaxed">
@@ -1082,9 +1112,7 @@
           size="sm"
           class="rounded-xl border-0 font-serif ring-0"
           :class="
-            workflow?.source === 'SHARED'
-              ? 'bg-alert-blue-muted text-alert-blue'
-              : 'bg-primary-muted text-primary-dark'
+            workflow?.source === 'SHARED' ? 'bg-alert-blue-muted text-alert-blue' : 'bg-primary-muted text-primary-dark'
           "
         >
           {{ workflow?.source === 'SHARED' ? 'Shared' : 'Private' }}

--- a/packages/front-end/src/app/composables/useUser.ts
+++ b/packages/front-end/src/app/composables/useUser.ts
@@ -116,8 +116,9 @@ export default function useUser() {
       const token = await useAuth().getToken();
       const decodedToken: any = decodeJwt(token);
 
-      // retrieve and set account id and email
-      userStore.currentUserDetails.id = decodedToken['cognito:username'];
+      // Prefer the platform UserId claim (DynamoDB) when present; fall back to Cognito username.
+      // Seeded Cognito users can have a different cognito:username than the DynamoDB UserId.
+      userStore.currentUserDetails.id = decodedToken.UserId || decodedToken['cognito:username'];
       userStore.currentUserDetails.email = decodedToken.email;
 
       // Sync the server-side analytics consent choice so it follows the user

--- a/packages/front-end/src/app/pages/labs/[labId]/index.vue
+++ b/packages/front-end/src/app/pages/labs/[labId]/index.vue
@@ -2,11 +2,11 @@
   const $route = useRoute();
   const $router = useRouter();
 
-  const labId = $route.params.labId as string;
-  const initialTab = $route.query.tab as string;
+  const labId = computed(() => $route.params.labId as string);
+  const initialTab = computed(() => ($route.query.tab as string | undefined) ?? undefined);
 
   // check permissions to be on this page
-  if (!useUserStore().canViewLab(labId)) {
+  if (!useUserStore().canViewLab(labId.value)) {
     $router.push('/labs');
   }
 </script>

--- a/packages/front-end/src/app/repository/modules/labs.ts
+++ b/packages/front-end/src/app/repository/modules/labs.ts
@@ -263,9 +263,11 @@ class LabsModule extends HttpFactory {
   }
 
   async listLabRuns(labId: string, filters: object = {}): Promise<LaboratoryRun[]> {
-    let queryUrl = `/laboratory/run/list-laboratory-runs?LaboratoryId=${labId}`;
+    let queryUrl = `/laboratory/run/list-laboratory-runs?LaboratoryId=${encodeURIComponent(labId)}`;
 
-    for (const [filterKey, filterVal] of Object.entries(filters)) queryUrl += `&${filterKey}=${filterVal}`;
+    for (const [filterKey, filterVal] of Object.entries(filters)) {
+      queryUrl += `&${encodeURIComponent(filterKey)}=${encodeURIComponent(String(filterVal))}`;
+    }
 
     const res = await this.call<LaboratoryRun[]>('GET', queryUrl);
 

--- a/packages/front-end/src/app/utils/laboratory-run-ownership.ts
+++ b/packages/front-end/src/app/utils/laboratory-run-ownership.ts
@@ -1,0 +1,21 @@
+import { LaboratoryRun } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory-run';
+
+/**
+ * Whether a laboratory run was initiated by the given user.
+ *
+ * Matches on UserId (Cognito / platform user id) or Owner email. Owner is the
+ * reliable fallback when Cognito username and DynamoDB UserId diverge (e.g.
+ * seeded non-prod users with email sign-in aliases).
+ */
+export function isLaboratoryRunOwnedByUser(
+  run: Pick<LaboratoryRun, 'UserId' | 'Owner'>,
+  user: { id?: string | null; email?: string | null },
+): boolean {
+  if (user.id && run.UserId === user.id) {
+    return true;
+  }
+  if (user.email && run.Owner?.toLowerCase() === user.email.toLowerCase()) {
+    return true;
+  }
+  return false;
+}

--- a/packages/front-end/test/app/utils/laboratory-run-ownership.test.ts
+++ b/packages/front-end/test/app/utils/laboratory-run-ownership.test.ts
@@ -1,0 +1,39 @@
+import { isLaboratoryRunOwnedByUser } from '../../../src/app/utils/laboratory-run-ownership';
+
+describe('isLaboratoryRunOwnedByUser', () => {
+  const run = {
+    UserId: 'c6705721-90ba-4d4a-9460-af2828bb4181',
+    Owner: 'admin@easygenomics.org',
+  };
+
+  it('matches by UserId', () => {
+    expect(
+      isLaboratoryRunOwnedByUser(run, {
+        id: 'c6705721-90ba-4d4a-9460-af2828bb4181',
+        email: 'other@example.com',
+      }),
+    ).toBe(true);
+  });
+
+  it('matches by Owner email case-insensitively', () => {
+    expect(
+      isLaboratoryRunOwnedByUser(run, {
+        id: '00000000-0000-0000-0000-000000000099',
+        email: 'Admin@EasyGenomics.org',
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false when neither UserId nor Owner match', () => {
+    expect(
+      isLaboratoryRunOwnedByUser(run, {
+        id: '00000000-0000-0000-0000-000000000099',
+        email: 'other@example.com',
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false when user identity is missing', () => {
+    expect(isLaboratoryRunOwnedByUser(run, { id: null, email: null })).toBe(false);
+  });
+});


### PR DESCRIPTION
## feat: added my runs only switch to recent runs in dashboard

## Type of Change*
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Adds a “My runs only” toggle and “View all” link to the Dashboard Recent runs section, and updates Pipeline Runs to use the same toggle instead of a checkbox. Fixes the filter so it matches runs by the current user’s platform UserId or Owner email, which was why enabling it in QA could show an empty list.

## Testing*
Tested manually in local environment.

## Impact
Adds new functionality, no impact to existing features.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [x] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.