### PR TITLE
chore: Shorten Lab Settings card descriptions, move detail into hover tooltips

### DIFF
--- a/packages/front-end/src/app/components/EGFormLabDetails.vue
+++ b/packages/front-end/src/app/components/EGFormLabDetails.vue
@@ -1017,16 +1017,17 @@
       >
         <div class="mb-3 flex items-center gap-1.5">
           <p class="text-muted text-xs">
-            Documented HealthOmics error codes are always classified using a built-in lookup; the LLM is used only for
-            ambiguous HealthOmics codes and free-text Seqera errors. Each integration can use a different provider — for
-            example a cheaper model for high-volume Seqera traffic, a more accurate model for HealthOmics ambiguous
-            cases.
+            Documented HealthOmics error codes use a built-in lookup; the LLM only handles ambiguous or free-text cases.
           </p>
           <!-- Provider guidance: helps an admin decide which LLM to bring (Bedrock vs OpenAI vs Anthropic)
                before they pick one in the dropdowns below. -->
           <UTooltip :delay-duration="0" :ui="{ base: 'h-auto w-auto max-w-sm whitespace-normal text-left' }">
             <template #text>
               <div class="space-y-1.5 py-1">
+                <p>
+                  Each integration can use a different provider — for example a cheaper model for high-volume Seqera
+                  traffic, a more accurate model for HealthOmics ambiguous cases.
+                </p>
                 <p class="font-medium text-black">Which provider should I choose?</p>
                 <p>
                   <span class="font-medium text-black">Amazon Bedrock</span>
@@ -1213,12 +1214,23 @@
           </UTooltip>
         </div>
 
-        <EGFormGroup
-          label="Networking mode"
-          name="AwsHealthOmicsNetworkingMode"
-          eager-validation
-          hint="Restricted (default) reaches only S3 and ECR in-region. VPC routes this lab's runs through a saved configuration. Only available when HealthOmics is enabled."
-        >
+        <EGFormGroup label="Networking mode" name="AwsHealthOmicsNetworkingMode" eager-validation>
+          <div class="mb-2 flex items-center gap-1.5">
+            <p class="text-muted text-xs">Only available when HealthOmics is enabled.</p>
+            <UTooltip :delay-duration="0" :ui="{ base: 'h-auto w-auto max-w-sm whitespace-normal text-left' }">
+              <template #text>
+                <p>
+                  Restricted (default) reaches only S3 and ECR in-region. VPC routes this lab's runs through a saved
+                  configuration.
+                </p>
+              </template>
+              <UIcon
+                name="i-heroicons-information-circle"
+                class="text-muted h-4 w-4 shrink-0"
+                aria-label="Networking mode guidance"
+              />
+            </UTooltip>
+          </div>
           <USelect
             v-model="state.AwsHealthOmicsNetworkingMode"
             :options="networkingModeOptions"

--- a/packages/front-end/src/app/components/EGFormLabDetails.vue
+++ b/packages/front-end/src/app/components/EGFormLabDetails.vue
@@ -1193,9 +1193,26 @@
       <EGCollapsibleSection
         heading-id="lab-settings-healthomics-vpc-networking-heading"
         title="HealthOmics VPC Networking"
-        description="Route this lab's HealthOmics runs through a saved VPC configuration so they can reach resources outside the default restricted network, for example internet reference datasets, license servers, or private VPC and on-prem data. Restricted runs can only reach S3 and ECR in-region."
+        description="Route this lab's HealthOmics runs through a custom VPC configuration."
         :badges="[healthOmicsVpcNetworkingBadge]"
       >
+        <div class="mb-3 flex items-center gap-1.5">
+          <p class="text-muted text-xs">Routes this lab's HealthOmics runs through a saved VPC configuration.</p>
+          <UTooltip :delay-duration="0" :ui="{ base: 'h-auto w-auto max-w-sm whitespace-normal text-left' }">
+            <template #text>
+              <p>
+                Lets runs reach resources outside the default restricted network — for example internet reference
+                datasets, license servers, or private VPC and on-prem data.
+              </p>
+            </template>
+            <UIcon
+              name="i-heroicons-information-circle"
+              class="text-muted h-4 w-4 shrink-0"
+              aria-label="VPC networking guidance"
+            />
+          </UTooltip>
+        </div>
+
         <EGFormGroup
           label="Networking mode"
           name="AwsHealthOmicsNetworkingMode"


### PR DESCRIPTION
## Title*
[UI] Shorten Lab Settings card descriptions, move detail into hover tooltips

## Type of Change*
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [x] UI/UX improvement

## Description
The Lab Settings page (`EGFormLabDetails.vue`) had several always-visible, multi-sentence card/field descriptions that cluttered the page, while the `AI Failure Analysis` card already used a cleaner pattern: a short one-line description with supplementary detail behind an info-icon hover tooltip. This PR extends that pattern to the rest of the page:

- **HealthOmics VPC Networking** card header: shortened the two-sentence `description` prop to one sentence ("Route this lab's HealthOmics runs through a custom VPC configuration.") and moved the "reach resources outside the default restricted network — reference datasets, license servers, on-prem data" detail into a new info-icon tooltip in the card body.
- **Networking mode** field: replaced the long `hint` prop ("Restricted (default) reaches only S3 and ECR in-region. VPC routes this lab's runs through a saved configuration. Only available when HealthOmics is enabled.") with a short visible line ("Only available when HealthOmics is enabled.") plus an info-icon tooltip holding the Restricted vs. VPC explanation.
- **AI Failure Analysis** intro paragraph: shortened the visible text to one sentence and folded the "each integration can use a different provider" note into the existing "Which provider should I choose?" tooltip, reusing that icon rather than adding a new one.

No information was deleted — everything removed from always-visible text was relocated into a hover tooltip. No logic, schema, or component-prop changes; this is a template-only edit to a single file.

**Out of scope:** the in-progress `Run Notifications` card (branch `feat/lab-02-email-notifications`) already ships a short header description and isn't touched here; the near-duplicated HealthOmics/Seqera LLM-provider field blocks in `AI Failure Analysis` are a separate code-duplication cleanup, not addressed by this PR.

## Testing
- `pnpm lint` and `pnpm test` in `packages/front-end`: pass (9 suites / 73 tests), unaffected by this change since no test covers this component.
- Full monorepo pre-commit hook (back-end suite + shared-lib OpenAPI regen) passed on both commits: 91 suites / 668 tests.
- Verified the edited template compiles with no Vue SFC errors (`@vue/compiler-sfc`).
- Not yet verified — to verify: open a Lab's Settings tab in the browser, confirm the `HealthOmics VPC Networking` card and `Networking mode` field show only the short text when collapsed/unfocused, and that hovering/focusing each info icon reveals the relocated detail; confirm the `AI Failure Analysis` tooltip still shows both the provider-choice note and the existing Bedrock/Anthropic/OpenAI guidance.

## Impact
Front-end only, presentation-level change in one Vue component. No new dependencies, no new network calls, no behavior change to any form field's value, validation, or submission logic — purely what text is visible by default vs. behind a hover.

## Additional Information
Ticket and implementation plan (outside the repo, per this project's convention): `superpowers/2026-08-04-lab-settings-description-cleanup-jira-ticket.md` and `superpowers/plans/2026-08-04-lab-settings-description-cleanup-plan.md`.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary. *(no new tests added — presentation-only change, no existing test covers this component, matches this repo's convention of manual testing for this class of change)*
- [ ] Documentation has been updated accordingly. *(N/A — no user-facing docs reference this card's copy)*
- [x] Code adheres to the coding and style guidelines of the project.
- [ ] Code has been commented in particularly hard-to-understand areas. *(N/A — no new comments needed; existing section comments left as-is)*