### PR TITLE
fix: create-laboratory-run throws an unclassified error on a legitimate retry with the same RunId

### DIFF
--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/create-laboratory-run.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/create-laboratory-run.lambda.ts
@@ -39,7 +39,7 @@ const runCostEstimationService = new RunCostEstimationService();
 const sqsService = new SqsService();
 
 /**
- * Best-effort input profile + pre-run estimate. Runs after laboratoryRunService.add()
+ * Best-effort input profile + pre-run estimate. Runs after laboratoryRunService.addOrGetExisting()
  * so a timeout here cannot leave an externally-submitted run untracked.
  */
 async function attachPreRunCostEstimate(
@@ -121,31 +121,34 @@ export const handler: Handler = async (
 
     // Persist the run first so an external platform submission is never left untracked
     // if subsequent best-effort cost estimation times out.
-    let laboratoryRun: LaboratoryRun = await laboratoryRunService.addOrGetExisting(<LaboratoryRun>{
-      LaboratoryId: laboratory.LaboratoryId,
-      RunId: request.RunId,
-      UserId: currentUserId,
-      OrganizationId: laboratory.OrganizationId,
-      RunName: request.RunName,
-      ...(request.Description ? { Description: request.Description } : {}),
-      Platform: request.Platform,
-      PlatformApiBaseUrl: request.PlatformApiBaseUrl,
-      Status: request.Status,
-      Owner: currentUserEmail,
-      WorkflowName: request.WorkflowName,
-      WorkflowVersionName: request.WorkflowVersionName,
-      WorkflowExternalId: request.WorkflowExternalId,
-      InputFileKeys: request.InputFileKeys,
-      ExternalRunId: request.ExternalRunId,
-      InputS3Url: request.InputS3Url,
-      OutputS3Url: request.OutputS3Url,
-      SampleSheetS3Url: request.SampleSheetS3Url,
-      Settings: JSON.stringify(request.Settings || {}),
-      CreatedAt: createdAt.toISOString(),
-      CreatedBy: currentUserId,
-      ...(isTerminalAtCreate ? { TerminalAt: createdAt.toISOString() } : {}),
-      ...(laboratorioRunExpiresAt !== undefined ? { ExpiresAt: laboratorioRunExpiresAt } : {}),
-    }, currentUserId);
+    let laboratoryRun: LaboratoryRun = await laboratoryRunService.addOrGetExisting(
+      <LaboratoryRun>{
+        LaboratoryId: laboratory.LaboratoryId,
+        RunId: request.RunId,
+        UserId: currentUserId,
+        OrganizationId: laboratory.OrganizationId,
+        RunName: request.RunName,
+        ...(request.Description ? { Description: request.Description } : {}),
+        Platform: request.Platform,
+        PlatformApiBaseUrl: request.PlatformApiBaseUrl,
+        Status: request.Status,
+        Owner: currentUserEmail,
+        WorkflowName: request.WorkflowName,
+        WorkflowVersionName: request.WorkflowVersionName,
+        WorkflowExternalId: request.WorkflowExternalId,
+        InputFileKeys: request.InputFileKeys,
+        ExternalRunId: request.ExternalRunId,
+        InputS3Url: request.InputS3Url,
+        OutputS3Url: request.OutputS3Url,
+        SampleSheetS3Url: request.SampleSheetS3Url,
+        Settings: JSON.stringify(request.Settings || {}),
+        CreatedAt: createdAt.toISOString(),
+        CreatedBy: currentUserId,
+        ...(isTerminalAtCreate ? { TerminalAt: createdAt.toISOString() } : {}),
+        ...(laboratorioRunExpiresAt !== undefined ? { ExpiresAt: laboratorioRunExpiresAt } : {}),
+      },
+      currentUserId,
+    );
 
     laboratoryRun = await attachPreRunCostEstimate(laboratory, laboratoryRun, request);
 

--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/create-laboratory-run.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/create-laboratory-run.lambda.ts
@@ -145,7 +145,6 @@ export const handler: Handler = async (
       CreatedBy: currentUserId,
       ...(isTerminalAtCreate ? { TerminalAt: createdAt.toISOString() } : {}),
       ...(laboratorioRunExpiresAt !== undefined ? { ExpiresAt: laboratorioRunExpiresAt } : {}),
-      ...(!isTerminalAtCreate ? { PollStatus: 'ACTIVE' } : {}),
     }, currentUserId);
 
     laboratoryRun = await attachPreRunCostEstimate(laboratory, laboratoryRun, request);
@@ -161,22 +160,18 @@ export const handler: Handler = async (
     });
 
     if (laboratoryRun.ExternalRunId) {
-      // Queue up run status checks (best-effort; failure here must not block the response)
-      try {
-        const record: SnsProcessingEvent = {
-          Operation: 'UPDATE',
-          Type: 'LaboratoryRun',
-          Record: laboratoryRun,
-        };
-        await sqsService.sendMessage({
-          QueueUrl: process.env.SQS_LABORATORY_RUN_UPDATE_QUEUE_URL,
-          MessageBody: JSON.stringify(record),
-          MessageGroupId: `update-laboratory-run-${laboratoryRun.RunId}`,
-          MessageDeduplicationId: uuidv4(),
-        });
-      } catch (err) {
-        console.warn('Failed to queue run status check (continuing):', err);
-      }
+      // Queue up run status checks
+      const record: SnsProcessingEvent = {
+        Operation: 'UPDATE',
+        Type: 'LaboratoryRun',
+        Record: laboratoryRun,
+      };
+      await sqsService.sendMessage({
+        QueueUrl: process.env.SQS_LABORATORY_RUN_UPDATE_QUEUE_URL,
+        MessageBody: JSON.stringify(record),
+        MessageGroupId: `update-laboratory-run-${laboratoryRun.RunId}`,
+        MessageDeduplicationId: uuidv4(),
+      });
     }
 
     return buildResponse(200, JSON.stringify(laboratoryRun), event);

--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/create-laboratory-run.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/create-laboratory-run.lambda.ts
@@ -121,7 +121,7 @@ export const handler: Handler = async (
 
     // Persist the run first so an external platform submission is never left untracked
     // if subsequent best-effort cost estimation times out.
-    let laboratoryRun: LaboratoryRun = await laboratoryRunService.add(<LaboratoryRun>{
+    let laboratoryRun: LaboratoryRun = await laboratoryRunService.addOrGetExisting(<LaboratoryRun>{
       LaboratoryId: laboratory.LaboratoryId,
       RunId: request.RunId,
       UserId: currentUserId,
@@ -145,7 +145,8 @@ export const handler: Handler = async (
       CreatedBy: currentUserId,
       ...(isTerminalAtCreate ? { TerminalAt: createdAt.toISOString() } : {}),
       ...(laboratorioRunExpiresAt !== undefined ? { ExpiresAt: laboratorioRunExpiresAt } : {}),
-    });
+      ...(!isTerminalAtCreate ? { PollStatus: 'ACTIVE' } : {}),
+    }, currentUserId);
 
     laboratoryRun = await attachPreRunCostEstimate(laboratory, laboratoryRun, request);
 
@@ -160,18 +161,22 @@ export const handler: Handler = async (
     });
 
     if (laboratoryRun.ExternalRunId) {
-      // Queue up run status checks
-      const record: SnsProcessingEvent = {
-        Operation: 'UPDATE',
-        Type: 'LaboratoryRun',
-        Record: laboratoryRun,
-      };
-      await sqsService.sendMessage({
-        QueueUrl: process.env.SQS_LABORATORY_RUN_UPDATE_QUEUE_URL,
-        MessageBody: JSON.stringify(record),
-        MessageGroupId: `update-laboratory-run-${laboratoryRun.RunId}`,
-        MessageDeduplicationId: uuidv4(),
-      });
+      // Queue up run status checks (best-effort; failure here must not block the response)
+      try {
+        const record: SnsProcessingEvent = {
+          Operation: 'UPDATE',
+          Type: 'LaboratoryRun',
+          Record: laboratoryRun,
+        };
+        await sqsService.sendMessage({
+          QueueUrl: process.env.SQS_LABORATORY_RUN_UPDATE_QUEUE_URL,
+          MessageBody: JSON.stringify(record),
+          MessageGroupId: `update-laboratory-run-${laboratoryRun.RunId}`,
+          MessageDeduplicationId: uuidv4(),
+        });
+      } catch (err) {
+        console.warn('Failed to queue run status check (continuing):', err);
+      }
     }
 
     return buildResponse(200, JSON.stringify(laboratoryRun), event);

--- a/packages/back-end/src/app/services/easy-genomics/laboratory-run-service.ts
+++ b/packages/back-end/src/app/services/easy-genomics/laboratory-run-service.ts
@@ -10,6 +10,7 @@ import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
 import { LaboratoryRunSchema } from '@easy-genomics/shared-lib/src/app/schema/easy-genomics/laboratory-run';
 import { LaboratoryRun } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory-run';
 import { LaboratoryRunAlreadyExistsError, LaboratoryRunNotFoundError } from '@easy-genomics/shared-lib/src/app/utils/HttpError';
+import { isConditionalCheckFailed } from './laboratory-data-tagging-service';
 import { Service } from '../../types/service';
 import { DynamoDBService } from '../dynamodb-service';
 
@@ -98,8 +99,8 @@ export class LaboratoryRunService extends DynamoDBService implements Service<Lab
   ): Promise<LaboratoryRun> => {
     try {
       return await this.add(laboratoryRun);
-    } catch (err: any) {
-      if (err?.name !== 'ConditionalCheckFailedException') throw err;
+    } catch (err: unknown) {
+      if (!isConditionalCheckFailed(err)) throw err;
       const existing = await this.get(laboratoryRun.LaboratoryId, laboratoryRun.RunId);
       if (existing.UserId === requestingUserId) return existing;
       throw new LaboratoryRunAlreadyExistsError();

--- a/packages/back-end/src/app/services/easy-genomics/laboratory-run-service.ts
+++ b/packages/back-end/src/app/services/easy-genomics/laboratory-run-service.ts
@@ -9,7 +9,7 @@ import {
 import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
 import { LaboratoryRunSchema } from '@easy-genomics/shared-lib/src/app/schema/easy-genomics/laboratory-run';
 import { LaboratoryRun } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory-run';
-import { LaboratoryRunNotFoundError } from '@easy-genomics/shared-lib/src/app/utils/HttpError';
+import { LaboratoryRunAlreadyExistsError, LaboratoryRunNotFoundError } from '@easy-genomics/shared-lib/src/app/utils/HttpError';
 import { Service } from '../../types/service';
 import { DynamoDBService } from '../dynamodb-service';
 
@@ -81,6 +81,28 @@ export class LaboratoryRunService extends DynamoDBService implements Service<Lab
       return laboratoryRun;
     } else {
       throw new Error(`${logRequestMessage} unsuccessful: HTTP Status Code=${response.$metadata.httpStatusCode}`);
+    }
+  };
+
+  /**
+   * Same conditional-insert as `add`, but treats a same-user retry as a successful replay
+   * instead of throwing. `RunId` is a client-generated idempotency token that's intentionally
+   * reused across retries one step earlier (the AWS HealthOmics submission) — a double-click
+   * or the front-end's auto-retry-on-EG-110 can resubmit the identical create-laboratory-run
+   * request. Only the requester's own prior write is treated as a replay; a RunId collision
+   * with a different user's run is a genuine anomaly, not a retry, so it's still rejected.
+   */
+  public addOrGetExisting = async (
+    laboratoryRun: LaboratoryRun,
+    requestingUserId: string,
+  ): Promise<LaboratoryRun> => {
+    try {
+      return await this.add(laboratoryRun);
+    } catch (err: any) {
+      if (err?.name !== 'ConditionalCheckFailedException') throw err;
+      const existing = await this.get(laboratoryRun.LaboratoryId, laboratoryRun.RunId);
+      if (existing.UserId === requestingUserId) return existing;
+      throw new LaboratoryRunAlreadyExistsError();
     }
   };
 

--- a/packages/back-end/src/app/services/easy-genomics/laboratory-run-service.ts
+++ b/packages/back-end/src/app/services/easy-genomics/laboratory-run-service.ts
@@ -9,7 +9,10 @@ import {
 import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
 import { LaboratoryRunSchema } from '@easy-genomics/shared-lib/src/app/schema/easy-genomics/laboratory-run';
 import { LaboratoryRun } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory-run';
-import { LaboratoryRunAlreadyExistsError, LaboratoryRunNotFoundError } from '@easy-genomics/shared-lib/src/app/utils/HttpError';
+import {
+  LaboratoryRunAlreadyExistsError,
+  LaboratoryRunNotFoundError,
+} from '@easy-genomics/shared-lib/src/app/utils/HttpError';
 import { isConditionalCheckFailed } from './laboratory-data-tagging-service';
 import { Service } from '../../types/service';
 import { DynamoDBService } from '../dynamodb-service';
@@ -87,23 +90,24 @@ export class LaboratoryRunService extends DynamoDBService implements Service<Lab
 
   /**
    * Same conditional-insert as `add`, but treats a same-user retry as a successful replay
-   * instead of throwing. `RunId` is a client-generated idempotency token that's intentionally
-   * reused across retries one step earlier (the AWS HealthOmics submission) — a double-click
-   * or the front-end's auto-retry-on-EG-110 can resubmit the identical create-laboratory-run
-   * request. Only the requester's own prior write is treated as a replay; a RunId collision
-   * with a different user's run is a genuine anomaly, not a retry, so it's still rejected.
+   * instead of throwing. This is reachable because the run row can be persisted successfully
+   * while a later step in create-laboratory-run.lambda.ts (e.g. the SQS status-check enqueue)
+   * still fails, returning an error to the client even though the write succeeded. The client
+   * then resubmits with the same `RunId`, since AWS HealthOmics returns the same execution for
+   * the same idempotency token, which hits this conditional insert a second time. Only the
+   * requester's own prior write is treated as a replay; a RunId collision with a different
+   * user's run is a genuine anomaly, not a retry, so it's still rejected.
    */
-  public addOrGetExisting = async (
-    laboratoryRun: LaboratoryRun,
-    requestingUserId: string,
-  ): Promise<LaboratoryRun> => {
+  public addOrGetExisting = async (laboratoryRun: LaboratoryRun, requestingUserId: string): Promise<LaboratoryRun> => {
     try {
       return await this.add(laboratoryRun);
     } catch (err: unknown) {
       if (!isConditionalCheckFailed(err)) throw err;
       const existing = await this.get(laboratoryRun.LaboratoryId, laboratoryRun.RunId);
       if (existing.UserId === requestingUserId) return existing;
-      throw new LaboratoryRunAlreadyExistsError();
+      throw new LaboratoryRunAlreadyExistsError(
+        `RunId=${laboratoryRun.RunId} already exists for LaboratoryId=${laboratoryRun.LaboratoryId} under a different user`,
+      );
     }
   };
 

--- a/packages/back-end/test/app/controllers/easy-genomics/laboratory/run/create-laboratory-run.lambda.test.ts
+++ b/packages/back-end/test/app/controllers/easy-genomics/laboratory/run/create-laboratory-run.lambda.test.ts
@@ -158,29 +158,6 @@ describe('create-laboratory-run.lambda', () => {
     expect(mockSqsService.prototype.sendMessage).toHaveBeenCalled();
   });
 
-  it('still returns 200 with the persisted run when queuing the status check fails', async () => {
-    (mockLabService.prototype.queryByLaboratoryId as jest.Mock).mockResolvedValue({
-      OrganizationId: '00000000-0000-0000-0000-000000000001',
-      LaboratoryId: LAB_ID,
-    });
-
-    (mockRunService.prototype.addOrGetExisting as jest.Mock).mockResolvedValue({
-      ...baseRequest,
-      OrganizationId: '00000000-0000-0000-0000-000000000001',
-      Owner: 'user@example.com',
-      Settings: JSON.stringify({ param: 'value' }),
-    });
-
-    (mockSqsService.prototype.sendMessage as jest.Mock).mockRejectedValue(new Error('SQS unavailable'));
-
-    const result = await handler(createEvent(baseRequest), createContext(), () => {});
-
-    expect(result.statusCode).toBe(200);
-    const body = JSON.parse(result.body);
-    expect(body.RunId).toBe(RUN_ID);
-    expect(mockSqsService.prototype.sendMessage).toHaveBeenCalled();
-  });
-
   it('passes WorkflowVersionName through to laboratory run addOrGetExisting when provided', async () => {
     (mockLabService.prototype.queryByLaboratoryId as jest.Mock).mockResolvedValue({
       OrganizationId: '00000000-0000-0000-0000-000000000001',
@@ -312,34 +289,6 @@ describe('create-laboratory-run.lambda', () => {
 
     expect(result.statusCode).toBe(403);
     expect(mockRunService.prototype.addOrGetExisting).not.toHaveBeenCalled();
-  });
-
-  it('sets PollStatus=ACTIVE on a newly created non-terminal run', async () => {
-    (mockLabService.prototype.queryByLaboratoryId as jest.Mock).mockResolvedValue({
-      LaboratoryId: LAB_ID,
-      OrganizationId: '00000000-0000-0000-0000-000000000001',
-    });
-    const addOrGetExistingSpy = jest.fn().mockImplementation((run) => Promise.resolve(run));
-    mockRunService.prototype.addOrGetExisting = addOrGetExistingSpy;
-
-    const event = createEvent(baseRequest);
-    await handler(event, createContext(), () => {});
-
-    expect(addOrGetExistingSpy).toHaveBeenCalledWith(expect.objectContaining({ PollStatus: 'ACTIVE' }), 'user-1');
-  });
-
-  it('does not set PollStatus when the run is created already terminal', async () => {
-    (mockLabService.prototype.queryByLaboratoryId as jest.Mock).mockResolvedValue({
-      LaboratoryId: LAB_ID,
-      OrganizationId: '00000000-0000-0000-0000-000000000001',
-    });
-    const addOrGetExistingSpy = jest.fn().mockImplementation((run) => Promise.resolve(run));
-    mockRunService.prototype.addOrGetExisting = addOrGetExistingSpy;
-
-    const event = createEvent({ ...baseRequest, Status: 'COMPLETED' });
-    await handler(event, createContext(), () => {});
-
-    expect(addOrGetExistingSpy).toHaveBeenCalledWith(expect.not.objectContaining({ PollStatus: 'ACTIVE' }), 'user-1');
   });
 
   it('persists the run before attaching cost estimate, and still succeeds if estimate fails', async () => {

--- a/packages/back-end/test/app/controllers/easy-genomics/laboratory/run/create-laboratory-run.lambda.test.ts
+++ b/packages/back-end/test/app/controllers/easy-genomics/laboratory/run/create-laboratory-run.lambda.test.ts
@@ -28,6 +28,7 @@ import {
   validateLaboratoryManagerAccess,
   validateLaboratoryTechnicianAccess,
 } from '../../../../../../src/app/utils/auth-utils';
+import { LaboratoryRunAlreadyExistsError } from '@easy-genomics/shared-lib/lib/app/utils/HttpError';
 
 describe('create-laboratory-run.lambda', () => {
   const LAB_ID = '00000000-0000-0000-0000-000000000002';
@@ -110,7 +111,7 @@ describe('create-laboratory-run.lambda', () => {
     mockValidateLabTechnician.mockReturnValue(false);
 
     mockLabService.prototype.queryByLaboratoryId = jest.fn();
-    mockRunService.prototype.add = jest.fn();
+    mockRunService.prototype.addOrGetExisting = jest.fn();
     mockRunService.prototype.update = jest.fn().mockImplementation(async (r) => r);
     mockSqsService.prototype.sendMessage = jest.fn();
     mockBuildRunInputProfile.mockResolvedValue({
@@ -139,7 +140,7 @@ describe('create-laboratory-run.lambda', () => {
       LaboratoryId: LAB_ID,
     });
 
-    (mockRunService.prototype.add as jest.Mock).mockResolvedValue({
+    (mockRunService.prototype.addOrGetExisting as jest.Mock).mockResolvedValue({
       ...baseRequest,
       OrganizationId: '00000000-0000-0000-0000-000000000001',
       Owner: 'user@example.com',
@@ -153,17 +154,40 @@ describe('create-laboratory-run.lambda', () => {
     expect(body.LaboratoryId).toBe(LAB_ID);
     expect(body.RunId).toBe(RUN_ID);
     expect(mockLabService.prototype.queryByLaboratoryId).toHaveBeenCalledWith(LAB_ID);
-    expect(mockRunService.prototype.add).toHaveBeenCalled();
+    expect(mockRunService.prototype.addOrGetExisting).toHaveBeenCalled();
     expect(mockSqsService.prototype.sendMessage).toHaveBeenCalled();
   });
 
-  it('passes WorkflowVersionName through to laboratory run add when provided', async () => {
+  it('still returns 200 with the persisted run when queuing the status check fails', async () => {
     (mockLabService.prototype.queryByLaboratoryId as jest.Mock).mockResolvedValue({
       OrganizationId: '00000000-0000-0000-0000-000000000001',
       LaboratoryId: LAB_ID,
     });
 
-    (mockRunService.prototype.add as jest.Mock).mockResolvedValue({
+    (mockRunService.prototype.addOrGetExisting as jest.Mock).mockResolvedValue({
+      ...baseRequest,
+      OrganizationId: '00000000-0000-0000-0000-000000000001',
+      Owner: 'user@example.com',
+      Settings: JSON.stringify({ param: 'value' }),
+    });
+
+    (mockSqsService.prototype.sendMessage as jest.Mock).mockRejectedValue(new Error('SQS unavailable'));
+
+    const result = await handler(createEvent(baseRequest), createContext(), () => {});
+
+    expect(result.statusCode).toBe(200);
+    const body = JSON.parse(result.body);
+    expect(body.RunId).toBe(RUN_ID);
+    expect(mockSqsService.prototype.sendMessage).toHaveBeenCalled();
+  });
+
+  it('passes WorkflowVersionName through to laboratory run addOrGetExisting when provided', async () => {
+    (mockLabService.prototype.queryByLaboratoryId as jest.Mock).mockResolvedValue({
+      OrganizationId: '00000000-0000-0000-0000-000000000001',
+      LaboratoryId: LAB_ID,
+    });
+
+    (mockRunService.prototype.addOrGetExisting as jest.Mock).mockResolvedValue({
       ...baseRequest,
       Platform: 'AWS HealthOmics',
       WorkflowVersionName: 'my-omics-version',
@@ -181,20 +205,21 @@ describe('create-laboratory-run.lambda', () => {
     const result = await handler(createEvent(body), createContext(), () => {});
 
     expect(result.statusCode).toBe(200);
-    expect(mockRunService.prototype.add).toHaveBeenCalledWith(
+    expect(mockRunService.prototype.addOrGetExisting).toHaveBeenCalledWith(
       expect.objectContaining({
         WorkflowVersionName: 'my-omics-version',
       }),
+      'user-1',
     );
   });
 
-  it('passes Description through to laboratory run add when provided', async () => {
+  it('passes Description through to laboratory run addOrGetExisting when provided', async () => {
     (mockLabService.prototype.queryByLaboratoryId as jest.Mock).mockResolvedValue({
       OrganizationId: '00000000-0000-0000-0000-000000000001',
       LaboratoryId: LAB_ID,
     });
 
-    (mockRunService.prototype.add as jest.Mock).mockResolvedValue({
+    (mockRunService.prototype.addOrGetExisting as jest.Mock).mockResolvedValue({
       ...baseRequest,
       Description: 'My run notes',
       OrganizationId: '00000000-0000-0000-0000-000000000001',
@@ -210,20 +235,21 @@ describe('create-laboratory-run.lambda', () => {
     const result = await handler(createEvent(body), createContext(), () => {});
 
     expect(result.statusCode).toBe(200);
-    expect(mockRunService.prototype.add).toHaveBeenCalledWith(
+    expect(mockRunService.prototype.addOrGetExisting).toHaveBeenCalledWith(
       expect.objectContaining({
         Description: 'My run notes',
       }),
+      'user-1',
     );
   });
 
-  it('omits Description from laboratory run add when not provided', async () => {
+  it('omits Description from laboratory run addOrGetExisting when not provided', async () => {
     (mockLabService.prototype.queryByLaboratoryId as jest.Mock).mockResolvedValue({
       OrganizationId: '00000000-0000-0000-0000-000000000001',
       LaboratoryId: LAB_ID,
     });
 
-    (mockRunService.prototype.add as jest.Mock).mockResolvedValue({
+    (mockRunService.prototype.addOrGetExisting as jest.Mock).mockResolvedValue({
       ...baseRequest,
       OrganizationId: '00000000-0000-0000-0000-000000000001',
       Owner: 'user@example.com',
@@ -233,7 +259,7 @@ describe('create-laboratory-run.lambda', () => {
     const result = await handler(createEvent(baseRequest), createContext(), () => {});
 
     expect(result.statusCode).toBe(200);
-    const addArg = (mockRunService.prototype.add as jest.Mock).mock.calls[0][0];
+    const addArg = (mockRunService.prototype.addOrGetExisting as jest.Mock).mock.calls[0][0];
     expect(addArg).not.toHaveProperty('Description');
   });
 
@@ -243,7 +269,7 @@ describe('create-laboratory-run.lambda', () => {
       LaboratoryId: 'lab-1',
     });
 
-    (mockRunService.prototype.add as jest.Mock).mockResolvedValue({
+    (mockRunService.prototype.addOrGetExisting as jest.Mock).mockResolvedValue({
       ...baseRequest,
       ExternalRunId: undefined,
       OrganizationId: 'org-1',
@@ -261,7 +287,7 @@ describe('create-laboratory-run.lambda', () => {
     const result = await handler(createEvent({}), createContext(), () => {});
 
     expect(result.statusCode).toBe(400);
-    expect(mockRunService.prototype.add).not.toHaveBeenCalled();
+    expect(mockRunService.prototype.addOrGetExisting).not.toHaveBeenCalled();
   });
 
   it('returns 404 when laboratory is not found', async () => {
@@ -285,7 +311,35 @@ describe('create-laboratory-run.lambda', () => {
     const result = await handler(createEvent(baseRequest), createContext(), () => {});
 
     expect(result.statusCode).toBe(403);
-    expect(mockRunService.prototype.add).not.toHaveBeenCalled();
+    expect(mockRunService.prototype.addOrGetExisting).not.toHaveBeenCalled();
+  });
+
+  it('sets PollStatus=ACTIVE on a newly created non-terminal run', async () => {
+    (mockLabService.prototype.queryByLaboratoryId as jest.Mock).mockResolvedValue({
+      LaboratoryId: LAB_ID,
+      OrganizationId: '00000000-0000-0000-0000-000000000001',
+    });
+    const addOrGetExistingSpy = jest.fn().mockImplementation((run) => Promise.resolve(run));
+    mockRunService.prototype.addOrGetExisting = addOrGetExistingSpy;
+
+    const event = createEvent(baseRequest);
+    await handler(event, createContext(), () => {});
+
+    expect(addOrGetExistingSpy).toHaveBeenCalledWith(expect.objectContaining({ PollStatus: 'ACTIVE' }), 'user-1');
+  });
+
+  it('does not set PollStatus when the run is created already terminal', async () => {
+    (mockLabService.prototype.queryByLaboratoryId as jest.Mock).mockResolvedValue({
+      LaboratoryId: LAB_ID,
+      OrganizationId: '00000000-0000-0000-0000-000000000001',
+    });
+    const addOrGetExistingSpy = jest.fn().mockImplementation((run) => Promise.resolve(run));
+    mockRunService.prototype.addOrGetExisting = addOrGetExistingSpy;
+
+    const event = createEvent({ ...baseRequest, Status: 'COMPLETED' });
+    await handler(event, createContext(), () => {});
+
+    expect(addOrGetExistingSpy).toHaveBeenCalledWith(expect.not.objectContaining({ PollStatus: 'ACTIVE' }), 'user-1');
   });
 
   it('persists the run before attaching cost estimate, and still succeeds if estimate fails', async () => {
@@ -302,15 +356,16 @@ describe('create-laboratory-run.lambda', () => {
       Settings: JSON.stringify({ param: 'value' }),
       CreatedBy: 'user-1',
     };
-    (mockRunService.prototype.add as jest.Mock).mockResolvedValue(added);
+    (mockRunService.prototype.addOrGetExisting as jest.Mock).mockResolvedValue(added);
     mockBuildRunInputProfile.mockRejectedValue(new Error('S3 timeout'));
 
     const result = await handler(createEvent(baseRequest), createContext(), () => {});
 
     expect(result.statusCode).toBe(200);
-    expect(mockRunService.prototype.add).toHaveBeenCalled();
-    expect(mockRunService.prototype.add).toHaveBeenCalledWith(
+    expect(mockRunService.prototype.addOrGetExisting).toHaveBeenCalled();
+    expect(mockRunService.prototype.addOrGetExisting).toHaveBeenCalledWith(
       expect.not.objectContaining({ PreRunCostEstimate: expect.anything() }),
+      'user-1',
     );
   });
 
@@ -328,7 +383,7 @@ describe('create-laboratory-run.lambda', () => {
       Settings: JSON.stringify({ param: 'value' }),
       CreatedBy: 'user-1',
     };
-    (mockRunService.prototype.add as jest.Mock).mockResolvedValue(added);
+    (mockRunService.prototype.addOrGetExisting as jest.Mock).mockResolvedValue(added);
     mockBuildRunInputProfile.mockResolvedValue({
       SampleCount: 3,
       InputFileCount: 2,
@@ -364,5 +419,20 @@ describe('create-laboratory-run.lambda', () => {
         PreRunCostEstimate: expect.objectContaining({ MedianUsd: 2 }),
       }),
     );
+  });
+
+  it('returns a classified 400 (not a raw error) when addOrGetExisting reports a genuine RunId collision', async () => {
+    (mockLabService.prototype.queryByLaboratoryId as jest.Mock).mockResolvedValue({
+      OrganizationId: '00000000-0000-0000-0000-000000000001',
+      LaboratoryId: LAB_ID,
+    });
+
+    (mockRunService.prototype.addOrGetExisting as jest.Mock).mockRejectedValue(new LaboratoryRunAlreadyExistsError());
+
+    const result = await handler(createEvent(baseRequest), createContext(), () => {});
+
+    expect(result.statusCode).toBe(400);
+    const body = JSON.parse(result.body);
+    expect(body.ErrorCode).toBe('EG-336');
   });
 });

--- a/packages/back-end/test/app/controllers/easy-genomics/laboratory/run/create-laboratory-run.lambda.test.ts
+++ b/packages/back-end/test/app/controllers/easy-genomics/laboratory/run/create-laboratory-run.lambda.test.ts
@@ -1,3 +1,4 @@
+import { LaboratoryRunAlreadyExistsError } from '@easy-genomics/shared-lib/lib/app/utils/HttpError';
 import { APIGatewayProxyWithCognitoAuthorizerEvent, Context } from 'aws-lambda';
 
 const mockEstimate = jest.fn();
@@ -28,7 +29,6 @@ import {
   validateLaboratoryManagerAccess,
   validateLaboratoryTechnicianAccess,
 } from '../../../../../../src/app/utils/auth-utils';
-import { LaboratoryRunAlreadyExistsError } from '@easy-genomics/shared-lib/lib/app/utils/HttpError';
 
 describe('create-laboratory-run.lambda', () => {
   const LAB_ID = '00000000-0000-0000-0000-000000000002';

--- a/packages/back-end/test/app/services/easy-genomics/laboratory-run-service.test.ts
+++ b/packages/back-end/test/app/services/easy-genomics/laboratory-run-service.test.ts
@@ -36,9 +36,7 @@ describe('LaboratoryRunService.addOrGetExisting', () => {
     const svc = new LaboratoryRunService();
     const conditionalError = new Error('ConditionalCheckFailedException');
     conditionalError.name = 'ConditionalCheckFailedException';
-    const putItem = jest
-      .spyOn(svc as unknown as { putItem: jest.Mock }, 'putItem')
-      .mockRejectedValue(conditionalError);
+    const putItem = jest.spyOn(svc as unknown as { putItem: jest.Mock }, 'putItem').mockRejectedValue(conditionalError);
     const existing = validRun({ RunName: 'First attempt' });
     const get = jest.spyOn(svc, 'get').mockResolvedValue(existing);
 
@@ -55,9 +53,7 @@ describe('LaboratoryRunService.addOrGetExisting', () => {
     const svc = new LaboratoryRunService();
     const conditionalError = new Error('ConditionalCheckFailedException');
     conditionalError.name = 'ConditionalCheckFailedException';
-    const putItem = jest
-      .spyOn(svc as unknown as { putItem: jest.Mock }, 'putItem')
-      .mockRejectedValue(conditionalError);
+    const putItem = jest.spyOn(svc as unknown as { putItem: jest.Mock }, 'putItem').mockRejectedValue(conditionalError);
     const existing = validRun({ UserId: '00000000-0000-0000-0000-000000000099' });
     const get = jest.spyOn(svc, 'get').mockResolvedValue(existing);
 
@@ -72,9 +68,7 @@ describe('LaboratoryRunService.addOrGetExisting', () => {
     const svc = new LaboratoryRunService();
     const transientError = new Error('ProvisionedThroughputExceededException');
     transientError.name = 'ProvisionedThroughputExceededException';
-    const putItem = jest
-      .spyOn(svc as unknown as { putItem: jest.Mock }, 'putItem')
-      .mockRejectedValue(transientError);
+    const putItem = jest.spyOn(svc as unknown as { putItem: jest.Mock }, 'putItem').mockRejectedValue(transientError);
 
     const run = validRun();
 

--- a/packages/back-end/test/app/services/easy-genomics/laboratory-run-service.test.ts
+++ b/packages/back-end/test/app/services/easy-genomics/laboratory-run-service.test.ts
@@ -1,0 +1,84 @@
+process.env.NAME_PREFIX = 'unit-test';
+
+import { LaboratoryRunService } from '../../../../src/app/services/easy-genomics/laboratory-run-service';
+import { LaboratoryRunAlreadyExistsError } from '@easy-genomics/shared-lib/src/app/utils/HttpError';
+import { LaboratoryRun } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory-run';
+
+describe('LaboratoryRunService.addOrGetExisting', () => {
+  const validRun = (overrides: Partial<LaboratoryRun> = {}): LaboratoryRun =>
+    ({
+      LaboratoryId: '00000000-0000-0000-0000-000000000001',
+      RunId: '00000000-0000-0000-0000-000000000002',
+      UserId: '00000000-0000-0000-0000-000000000003',
+      OrganizationId: '00000000-0000-0000-0000-000000000004',
+      RunName: 'Test Run',
+      Platform: 'AWS HealthOmics',
+      Status: 'RUNNING',
+      Owner: 'user@example.com',
+      ...overrides,
+    }) as LaboratoryRun;
+
+  it('creates the run on the first write', async () => {
+    const svc = new LaboratoryRunService();
+    const putItem = jest
+      .spyOn(svc as unknown as { putItem: jest.Mock }, 'putItem')
+      .mockResolvedValue({ $metadata: { httpStatusCode: 200 } });
+
+    const run = validRun();
+    const result = await svc.addOrGetExisting(run, run.UserId);
+
+    expect(result).toEqual(run);
+    expect(putItem).toHaveBeenCalled();
+    putItem.mockRestore();
+  });
+
+  it('returns the existing run when the same user retries with the same RunId', async () => {
+    const svc = new LaboratoryRunService();
+    const conditionalError = new Error('ConditionalCheckFailedException');
+    conditionalError.name = 'ConditionalCheckFailedException';
+    const putItem = jest
+      .spyOn(svc as unknown as { putItem: jest.Mock }, 'putItem')
+      .mockRejectedValue(conditionalError);
+    const existing = validRun({ RunName: 'First attempt' });
+    const get = jest.spyOn(svc, 'get').mockResolvedValue(existing);
+
+    const retry = validRun({ RunName: 'Retry attempt' });
+    const result = await svc.addOrGetExisting(retry, retry.UserId);
+
+    expect(result).toEqual(existing);
+    expect(get).toHaveBeenCalledWith(retry.LaboratoryId, retry.RunId);
+    putItem.mockRestore();
+    get.mockRestore();
+  });
+
+  it('throws LaboratoryRunAlreadyExistsError when the existing run belongs to a different user', async () => {
+    const svc = new LaboratoryRunService();
+    const conditionalError = new Error('ConditionalCheckFailedException');
+    conditionalError.name = 'ConditionalCheckFailedException';
+    const putItem = jest
+      .spyOn(svc as unknown as { putItem: jest.Mock }, 'putItem')
+      .mockRejectedValue(conditionalError);
+    const existing = validRun({ UserId: '00000000-0000-0000-0000-000000000099' });
+    const get = jest.spyOn(svc, 'get').mockResolvedValue(existing);
+
+    const requester = validRun();
+
+    await expect(svc.addOrGetExisting(requester, requester.UserId)).rejects.toThrow(LaboratoryRunAlreadyExistsError);
+    putItem.mockRestore();
+    get.mockRestore();
+  });
+
+  it('rethrows non-conditional errors instead of swallowing them', async () => {
+    const svc = new LaboratoryRunService();
+    const transientError = new Error('ProvisionedThroughputExceededException');
+    transientError.name = 'ProvisionedThroughputExceededException';
+    const putItem = jest
+      .spyOn(svc as unknown as { putItem: jest.Mock }, 'putItem')
+      .mockRejectedValue(transientError);
+
+    const run = validRun();
+
+    await expect(svc.addOrGetExisting(run, run.UserId)).rejects.toThrow('ProvisionedThroughputExceededException');
+    putItem.mockRestore();
+  });
+});

--- a/packages/back-end/test/app/services/easy-genomics/laboratory-run-service.test.ts
+++ b/packages/back-end/test/app/services/easy-genomics/laboratory-run-service.test.ts
@@ -1,8 +1,8 @@
 process.env.NAME_PREFIX = 'unit-test';
 
-import { LaboratoryRunService } from '../../../../src/app/services/easy-genomics/laboratory-run-service';
-import { LaboratoryRunAlreadyExistsError } from '@easy-genomics/shared-lib/src/app/utils/HttpError';
 import { LaboratoryRun } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory-run';
+import { LaboratoryRunAlreadyExistsError } from '@easy-genomics/shared-lib/src/app/utils/HttpError';
+import { LaboratoryRunService } from '../../../../src/app/services/easy-genomics/laboratory-run-service';
 
 describe('LaboratoryRunService.addOrGetExisting', () => {
   const validRun = (overrides: Partial<LaboratoryRun> = {}): LaboratoryRun =>

--- a/packages/shared-lib/src/app/utils/HttpError.ts
+++ b/packages/shared-lib/src/app/utils/HttpError.ts
@@ -373,6 +373,17 @@ export class LaboratoryRunNotFoundError extends HttpError {
 }
 
 /**
+ * Laboratory Run already exists with this RunId, for a different user than the requester.
+ * A same-user collision is treated as an idempotent retry (see LaboratoryRunService.addOrGetExisting)
+ * and never reaches this error.
+ */
+export class LaboratoryRunAlreadyExistsError extends HttpError {
+  constructor(messageOpt?: string) {
+    super('Laboratory run already exists', 400, 'EG-336', messageOpt);
+  }
+}
+
+/**
  * Sequence set not found
  *
  * @param sequenceSetId


### PR DESCRIPTION
## Type of Change*
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
`create-laboratory-run`'s DynamoDB write (`LaboratoryRunService.add()`) uses a strict insert-only conditional expression (`attribute_not_exists(#LaboratoryId) AND attribute_not_exists(#RunId)`). `RunId` is a client-generated idempotency token (`omicsRunTempId`) that the front end intentionally reuses across retries as the idempotency key for the AWS HealthOmics submission — but the same value is then reused as `RunId` for the DynamoDB write, which has no retry tolerance. A legitimate retry (e.g. the run persists successfully, but a later best-effort step in the handler throws and the client sees an error and re-launches) resubmits the same `RunId` and throws a raw, unclassified `ConditionalCheckFailedException`, which the handler had no catch for — it fell through to a generic 400/`EG-100` with the raw AWS SDK message.

Fix, scoped entirely to the back-end:
- Added `LaboratoryRunService.addOrGetExisting(laboratoryRun, requestingUserId)` (`packages/back-end/src/app/services/easy-genomics/laboratory-run-service.ts`) — additive only, does not change `add()` or the shared `Service<T>` contract. On a conditional-write conflict (detected via the existing `isConditionalCheckFailed` helper already used cross-file by `laboratory-sample-service.ts`), it fetches the existing row and returns it if the requester's `UserId` matches (idempotent replay); if the existing row belongs to a different user, it throws a new typed `LaboratoryRunAlreadyExistsError` instead of silently returning someone else's run data.
- Added `LaboratoryRunAlreadyExistsError` (`packages/shared-lib/src/app/utils/HttpError.ts`, 400/`EG-336`) following the existing `XAlreadyExistsError` family convention.
- `create-laboratory-run.lambda.ts` now calls `addOrGetExisting(..., currentUserId)` instead of `add(...)` — the only handler change; every downstream best-effort step (cost estimate, workflow-tag association, SQS status-check enqueue) still runs unconditionally, since all three are already safe to re-run.

Out of scope / not touched: front-end, Zod schemas, CDK/infra. A front-end double-click guard was considered and intentionally left out — the backend fix already makes both a double-click and a client-side retry resolve to a clean success, so a UI-level guard isn't required for correctness.

## Testing*
Added automated regression coverage exercising the real code paths (only the AWS SDK boundary is mocked):
- `packages/back-end/test/app/services/easy-genomics/laboratory-run-service.test.ts` — new `addOrGetExisting` suite: first-write success, same-user retry returns the existing row, different-user collision throws `LaboratoryRunAlreadyExistsError`, non-conditional errors still rethrow.
- `packages/back-end/test/app/controllers/easy-genomics/laboratory/run/create-laboratory-run.lambda.test.ts` — existing 10 tests updated for the `addOrGetExisting` call, plus one new test confirming a collision produces a classified 400/`EG-336` response rather than a raw error.

Full suite results: `packages/back-end` 92/92 test suites (672/672 tests) passing, lint clean; `packages/shared-lib` 20/20 test suites (146/146 tests) passing, including `openapi-guard.test.ts`.

**Not yet verified:** a live, click-through reproduction in a running app. The original occurrence was reproduced via direct code-path tracing (the conditional expression, the unwrapped error, and the missing catch are all unconditional code, not timing-dependent) rather than a live UI session — an attempt to reproduce live was blocked by an expired AWS SSO session mid-investigation and wasn't retried. To verify manually: create a run, then re-POST the identical `create-laboratory-run` body with the same `RunId` → expect `200` with the original row; repeat with a different user's token reusing that `RunId` → expect `400`/`EG-336`.

## Impact
Back-end only (Lambda handler + one service method + one new error class). No front-end, Zod schema, or CDK/infra changes. No new dependencies. Behavior change is additive: a request that previously failed with an unclassified error on a same-user retry now succeeds; a genuine cross-user `RunId` collision (expected to be effectively unreachable in practice, since `RunId` is a client-generated v4 UUID) now gets a classified error instead of the same raw exception.

## Additional Information
Full design rationale and root-cause tracing are written up in `2026-08-04-run-record-retry-idempotency-design.md` and the implementation plan in `2026-08-04-run-record-retry-idempotency-plan.md` (both outside this repo, per this team's convention for planning docs).

Two plan-authoring corrections were caught and fixed during implementation and review, in case they're useful context for reviewers: (1) an earlier draft of the plan cited a same-file precedent that turned out to only exist on a different, unmerged branch — corrected to use the actual established `isConditionalCheckFailed` pattern; (2) an earlier draft's test brief briefly introduced out-of-scope `PollStatus`/SQS-try-catch behavior not requested by this fix — caught in review and reverted before merge. Neither trace remains in the final diff.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [ ] Documentation has been updated accordingly. *(N/A — no user-facing docs affected; manual verification steps are noted in the Testing section above instead of a TESTING.md update, since that file lives outside this repo)*
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas. *(the non-obvious "why would this retry ever happen" reasoning is documented in `addOrGetExisting`'s JSDoc)*
