### PR TITLE
fix(EGV-229): move task progress card above run detail tabs

### DIFF
--- a/packages/front-end/src/app/pages/labs/[labId]/run/[labRunId].vue
+++ b/packages/front-end/src/app/pages/labs/[labId]/run/[labRunId].vue
@@ -307,6 +307,22 @@
   const rowStyle = 'flex border-b p-6 text-sm';
   const rowLabelStyle = 'w-[200px] font-medium text-black';
   const rowContentStyle = 'text-muted text-left';
+
+  const showSeqeraProgressCard = computed(
+    () => labRun.value?.Platform === 'Seqera Cloud' && !!(seqeraFailureReason.value || seqeraProgress.value?.progress),
+  );
+
+  const showOmicsProgressCard = computed(
+    () =>
+      labRun.value?.Platform === 'AWS HealthOmics' &&
+      !!(
+        omicsFailureReason.value ||
+        omicsFailedTasks.value.length ||
+        (omicsProgress.value?.progress && !TERMINAL_STATUSES.has(labRun.value.Status))
+      ),
+  );
+
+  const showTaskProgressCard = computed(() => showSeqeraProgressCard.value || showOmicsProgressCard.value);
 </script>
 
 <template>
@@ -321,6 +337,104 @@
     show-lab-breadcrumb
     :breadcrumbs="[{ label: 'Lab Runs', to: labTab('Lab Runs') }, labRun?.RunName || '']"
   />
+
+  <div v-if="showTaskProgressCard" class="mb-6 space-y-3">
+    <!-- Seqera task-level progress for FAILED or RUNNING runs -->
+    <section
+      v-if="showSeqeraProgressCard"
+      class="stroke-light flex flex-col rounded-2xl border border-solid bg-white p-6 max-md:px-5"
+    >
+      <h3 class="mb-4 text-sm font-medium text-black">Task Breakdown</h3>
+      <div v-if="seqeraFailureReason" class="mb-4 rounded border border-red-200 bg-red-50 px-4 py-3 text-sm">
+        <p class="font-medium text-red-800">Failure reason</p>
+        <p class="text-red-700">{{ seqeraFailureReason }}</p>
+        <details v-if="seqeraErrorReport" class="mt-2">
+          <summary class="cursor-pointer text-xs text-red-600">Show full error report</summary>
+          <pre class="mt-2 whitespace-pre-wrap break-all text-xs text-red-600">{{ seqeraErrorReport }}</pre>
+        </details>
+      </div>
+      <template v-if="seqeraProgress?.progress">
+        <ul class="mb-4 flex flex-wrap gap-6 text-sm" aria-label="Task counts by status">
+          <li>
+            <span class="font-medium text-green-700">Succeeded:</span>
+            {{ seqeraProgress.progress.workflowProgress?.succeedCountFmt ?? '0' }}
+          </li>
+          <li>
+            <span class="font-medium text-red-700">Failed:</span>
+            {{ seqeraProgress.progress.workflowProgress?.failedCountFmt ?? '0' }}
+          </li>
+          <li>
+            <span class="text-body font-medium">Running:</span>
+            {{ seqeraProgress.progress.workflowProgress?.runningCountFmt ?? '0' }}
+          </li>
+        </ul>
+        <div v-if="seqeraProgress.progress.processesProgress?.length" class="space-y-2">
+          <div
+            v-for="proc in seqeraProgress.progress.processesProgress?.filter((p) => p.failed > 0)"
+            :key="proc.process"
+            class="rounded border border-red-200 bg-red-50 px-4 py-3 text-sm"
+          >
+            <p class="font-medium text-red-800">
+              <span class="sr-only">Failed process:</span>
+              {{ proc.process }}
+            </p>
+            <p class="text-red-600">{{ proc.failed }} task(s) failed</p>
+          </div>
+        </div>
+      </template>
+    </section>
+
+    <!-- Omics task progress + failures -->
+    <section
+      v-if="showOmicsProgressCard"
+      class="stroke-light flex flex-col rounded-2xl border border-solid bg-white p-6 max-md:px-5"
+    >
+      <h3 class="mb-4 text-sm font-medium text-black">
+        {{ labRun.Status === 'FAILED' ? 'Failed Tasks' : 'Task Progress' }}
+      </h3>
+      <div v-if="omicsProgress?.progress && !TERMINAL_STATUSES.has(labRun.Status)" class="mb-4">
+        <EGProgressBar
+          :percent="omicsProgress.progress.percent"
+          :completed="omicsProgress.progress.tasksCompleted"
+          :total="omicsProgress.progress.tasksTotal"
+        />
+        <ul class="mt-3 flex flex-wrap gap-6 text-sm" aria-label="Task counts by status">
+          <li>
+            <span class="font-medium text-green-700">Completed:</span>
+            {{ omicsProgress.progress.tasksCompleted }}
+          </li>
+          <li>
+            <span class="text-body font-medium">Running:</span>
+            {{ omicsProgress.progress.tasksRunning }}
+          </li>
+          <li>
+            <span class="font-medium text-red-700">Failed:</span>
+            {{ omicsProgress.progress.tasksFailed }}
+          </li>
+          <li>
+            <span class="text-muted font-medium">Total known:</span>
+            {{ omicsProgress.progress.tasksTotal }}
+          </li>
+        </ul>
+      </div>
+      <div v-if="omicsFailureReason" class="mb-4 rounded border border-red-200 bg-red-50 px-4 py-3 text-sm">
+        <p class="font-medium text-red-800">Failure reason</p>
+        <p class="text-red-700">{{ omicsFailureReason }}</p>
+      </div>
+      <div class="space-y-2">
+        <div
+          v-for="task in omicsFailedTasks"
+          :key="task.taskId"
+          class="rounded border border-red-200 bg-red-50 px-4 py-3 text-sm"
+        >
+          <p class="font-medium text-red-800">
+            <span class="sr-only">Failed task:</span>
+            Task {{ task.taskId }} — {{ task.name }}
+          </p>
+        </div>
+      </div>
+    </section>
+  </div>
 
   <EGDetailTabs
     :model-value="tabIndex"
@@ -456,107 +570,6 @@
               <span class="font-medium text-black">What to do next:</span>
               {{ labRun.FailureAction }}
             </p>
-          </div>
-        </section>
-
-        <!-- Seqera task-level progress for FAILED or RUNNING runs -->
-        <section
-          v-if="labRun?.Platform === 'Seqera Cloud' && (seqeraFailureReason || seqeraProgress?.progress)"
-          class="stroke-light flex flex-col rounded-none rounded-b-2xl border border-solid bg-white p-6 max-md:px-5"
-        >
-          <h3 class="mb-4 text-sm font-medium text-black">Task Breakdown</h3>
-          <div v-if="seqeraFailureReason" class="mb-4 rounded border border-red-200 bg-red-50 px-4 py-3 text-sm">
-            <p class="font-medium text-red-800">Failure reason</p>
-            <p class="text-red-700">{{ seqeraFailureReason }}</p>
-            <details v-if="seqeraErrorReport" class="mt-2">
-              <summary class="cursor-pointer text-xs text-red-600">Show full error report</summary>
-              <pre class="mt-2 whitespace-pre-wrap break-all text-xs text-red-600">{{ seqeraErrorReport }}</pre>
-            </details>
-          </div>
-          <template v-if="seqeraProgress?.progress">
-            <ul class="mb-4 flex flex-wrap gap-6 text-sm" aria-label="Task counts by status">
-              <li>
-                <span class="font-medium text-green-700">Succeeded:</span>
-                {{ seqeraProgress.progress.workflowProgress?.succeedCountFmt ?? '0' }}
-              </li>
-              <li>
-                <span class="font-medium text-red-700">Failed:</span>
-                {{ seqeraProgress.progress.workflowProgress?.failedCountFmt ?? '0' }}
-              </li>
-              <li>
-                <span class="text-body font-medium">Running:</span>
-                {{ seqeraProgress.progress.workflowProgress?.runningCountFmt ?? '0' }}
-              </li>
-            </ul>
-            <div v-if="seqeraProgress.progress.processesProgress?.length" class="space-y-2">
-              <div
-                v-for="proc in seqeraProgress.progress.processesProgress?.filter((p) => p.failed > 0)"
-                :key="proc.process"
-                class="rounded border border-red-200 bg-red-50 px-4 py-3 text-sm"
-              >
-                <p class="font-medium text-red-800">
-                  <span class="sr-only">Failed process:</span>
-                  {{ proc.process }}
-                </p>
-                <p class="text-red-600">{{ proc.failed }} task(s) failed</p>
-              </div>
-            </div>
-          </template>
-        </section>
-
-        <!-- Omics task progress + failures -->
-        <section
-          v-if="
-            labRun?.Platform === 'AWS HealthOmics' &&
-            (omicsFailureReason ||
-              omicsFailedTasks.length ||
-              (omicsProgress?.progress && !TERMINAL_STATUSES.has(labRun.Status)))
-          "
-          class="stroke-light flex flex-col rounded-none rounded-b-2xl border border-solid bg-white p-6 max-md:px-5"
-        >
-          <h3 class="mb-4 text-sm font-medium text-black">
-            {{ labRun.Status === 'FAILED' ? 'Failed Tasks' : 'Task Progress' }}
-          </h3>
-          <div v-if="omicsProgress?.progress && !TERMINAL_STATUSES.has(labRun.Status)" class="mb-4">
-            <EGProgressBar
-              :percent="omicsProgress.progress.percent"
-              :completed="omicsProgress.progress.tasksCompleted"
-              :total="omicsProgress.progress.tasksTotal"
-            />
-            <ul class="mt-3 flex flex-wrap gap-6 text-sm" aria-label="Task counts by status">
-              <li>
-                <span class="font-medium text-green-700">Completed:</span>
-                {{ omicsProgress.progress.tasksCompleted }}
-              </li>
-              <li>
-                <span class="text-body font-medium">Running:</span>
-                {{ omicsProgress.progress.tasksRunning }}
-              </li>
-              <li>
-                <span class="font-medium text-red-700">Failed:</span>
-                {{ omicsProgress.progress.tasksFailed }}
-              </li>
-              <li>
-                <span class="text-muted font-medium">Total known:</span>
-                {{ omicsProgress.progress.tasksTotal }}
-              </li>
-            </ul>
-          </div>
-          <div v-if="omicsFailureReason" class="mb-4 rounded border border-red-200 bg-red-50 px-4 py-3 text-sm">
-            <p class="font-medium text-red-800">Failure reason</p>
-            <p class="text-red-700">{{ omicsFailureReason }}</p>
-          </div>
-          <div class="space-y-2">
-            <div
-              v-for="task in omicsFailedTasks"
-              :key="task.taskId"
-              class="rounded border border-red-200 bg-red-50 px-4 py-3 text-sm"
-            >
-              <p class="font-medium text-red-800">
-                <span class="sr-only">Failed task:</span>
-                Task {{ task.taskId }} — {{ task.name }}
-              </p>
-            </div>
           </div>
         </section>
       </div>

--- a/packages/front-end/src/app/pages/labs/[labId]/run/[labRunId].vue
+++ b/packages/front-end/src/app/pages/labs/[labId]/run/[labRunId].vue
@@ -10,9 +10,12 @@
   import { TaskListItem, GetRunResponse } from '@aws-sdk/client-omics';
   import { useLabsStore, useRunStore, useUiStore } from '@FE/stores';
   import { ensureLabInActiveOrg } from '@FE/utils/ensure-lab-in-active-org';
+  import {
+    isTerminalRunStatus,
+    showOmicsTaskProgressCard,
+    showSeqeraTaskProgressCard,
+  } from '@FE/utils/run-progress-card-visibility';
   import { v4 as uuidv4 } from 'uuid';
-
-  const TERMINAL_STATUSES = new Set(['FAILED', 'SUCCEEDED', 'CANCELLED', 'COMPLETED', 'DELETED', 'ABORTED']);
 
   const $route = useRoute();
   const $router = useRouter();
@@ -135,7 +138,7 @@
       window.clearTimeout(progressPollTimeoutId);
     }
     const run = runStore.labRuns[labRunId];
-    if (!run || TERMINAL_STATUSES.has(run.Status)) return;
+    if (!run || isTerminalRunStatus(run.Status)) return;
 
     progressPollTimeoutId = window.setTimeout(async () => {
       if (!progressPollActive) return;
@@ -308,21 +311,20 @@
   const rowLabelStyle = 'w-[200px] font-medium text-black';
   const rowContentStyle = 'text-muted text-left';
 
-  const showSeqeraProgressCard = computed(
-    () => labRun.value?.Platform === 'Seqera Cloud' && !!(seqeraFailureReason.value || seqeraProgress.value?.progress),
+  const showSeqeraProgressCard = computed<boolean>(() =>
+    showSeqeraTaskProgressCard(labRun.value, {
+      failureReason: seqeraFailureReason.value,
+      hasProgress: !!seqeraProgress.value?.progress,
+    }),
   );
 
-  const showOmicsProgressCard = computed(
-    () =>
-      labRun.value?.Platform === 'AWS HealthOmics' &&
-      !!(
-        omicsFailureReason.value ||
-        omicsFailedTasks.value.length ||
-        (omicsProgress.value?.progress && !TERMINAL_STATUSES.has(labRun.value.Status))
-      ),
+  const showOmicsProgressCard = computed<boolean>(() =>
+    showOmicsTaskProgressCard(labRun.value, {
+      failureReason: omicsFailureReason.value,
+      failedTaskCount: omicsFailedTasks.value.length,
+      hasProgress: !!omicsProgress.value?.progress,
+    }),
   );
-
-  const showTaskProgressCard = computed(() => showSeqeraProgressCard.value || showOmicsProgressCard.value);
 </script>
 
 <template>
@@ -338,7 +340,7 @@
     :breadcrumbs="[{ label: 'Lab Runs', to: labTab('Lab Runs') }, labRun?.RunName || '']"
   />
 
-  <div v-if="showTaskProgressCard" class="mb-6 space-y-3">
+  <div v-if="showSeqeraProgressCard || showOmicsProgressCard" class="mb-6 space-y-3">
     <!-- Seqera task-level progress for FAILED or RUNNING runs -->
     <section
       v-if="showSeqeraProgressCard"
@@ -392,7 +394,7 @@
       <h3 class="mb-4 text-sm font-medium text-black">
         {{ labRun.Status === 'FAILED' ? 'Failed Tasks' : 'Task Progress' }}
       </h3>
-      <div v-if="omicsProgress?.progress && !TERMINAL_STATUSES.has(labRun.Status)" class="mb-4">
+      <div v-if="omicsProgress?.progress && !isTerminalRunStatus(labRun.Status)" class="mb-4">
         <EGProgressBar
           :percent="omicsProgress.progress.percent"
           :completed="omicsProgress.progress.tasksCompleted"

--- a/packages/front-end/src/app/utils/run-progress-card-visibility.ts
+++ b/packages/front-end/src/app/utils/run-progress-card-visibility.ts
@@ -1,0 +1,49 @@
+import { LaboratoryRun } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/laboratory-run';
+
+/**
+ * Statuses after which a run no longer emits task progress updates. Includes 'ABORTED'
+ * because the Seqera Platform reports it in place of 'CANCELLED'.
+ */
+const TERMINAL_RUN_STATUSES: ReadonlySet<string> = new Set([
+  'FAILED',
+  'SUCCEEDED',
+  'CANCELLED',
+  'COMPLETED',
+  'DELETED',
+  'ABORTED',
+]);
+
+export function isTerminalRunStatus(status: string | null | undefined): boolean {
+  return !!status && TERMINAL_RUN_STATUSES.has(status);
+}
+
+type RunPlatformAndStatus = Pick<LaboratoryRun, 'Platform' | 'Status'> | null | undefined;
+
+/**
+ * Whether the Seqera Task Breakdown card has anything to show: either a failure reason
+ * or a task progress payload.
+ */
+export function showSeqeraTaskProgressCard(
+  run: RunPlatformAndStatus,
+  content: { failureReason?: string | null; hasProgress?: boolean },
+): boolean {
+  if (run?.Platform !== 'Seqera Cloud') return false;
+
+  return !!content.failureReason || !!content.hasProgress;
+}
+
+/**
+ * Whether the HealthOmics Task Progress / Failed Tasks card has anything to show. Live
+ * progress is only rendered while the run is non-terminal, so it alone does not keep the
+ * card open once the run finishes — failure content does.
+ */
+export function showOmicsTaskProgressCard(
+  run: RunPlatformAndStatus,
+  content: { failureReason?: string | null; failedTaskCount?: number; hasProgress?: boolean },
+): boolean {
+  if (run?.Platform !== 'AWS HealthOmics') return false;
+
+  const { failureReason, failedTaskCount = 0, hasProgress = false } = content;
+
+  return !!failureReason || failedTaskCount > 0 || (hasProgress && !isTerminalRunStatus(run.Status));
+}

--- a/packages/front-end/test/app/utils/run-progress-card-visibility.test.ts
+++ b/packages/front-end/test/app/utils/run-progress-card-visibility.test.ts
@@ -1,0 +1,93 @@
+import {
+  isTerminalRunStatus,
+  showOmicsTaskProgressCard,
+  showSeqeraTaskProgressCard,
+} from '../../../src/app/utils/run-progress-card-visibility';
+
+const seqeraRun = { Platform: 'Seqera Cloud', Status: 'RUNNING' } as const;
+const omicsRun = { Platform: 'AWS HealthOmics', Status: 'RUNNING' } as const;
+
+describe('isTerminalRunStatus', () => {
+  it.each(['FAILED', 'SUCCEEDED', 'CANCELLED', 'COMPLETED', 'DELETED', 'ABORTED'])(
+    'treats %s as terminal',
+    (status) => {
+      expect(isTerminalRunStatus(status)).toBe(true);
+    },
+  );
+
+  it.each(['RUNNING', 'STARTING', 'PENDING', 'STOPPING'])('treats %s as non-terminal', (status) => {
+    expect(isTerminalRunStatus(status)).toBe(false);
+  });
+
+  it('returns false when the status is missing', () => {
+    expect(isTerminalRunStatus(undefined)).toBe(false);
+    expect(isTerminalRunStatus(null)).toBe(false);
+    expect(isTerminalRunStatus('')).toBe(false);
+  });
+});
+
+describe('showSeqeraTaskProgressCard', () => {
+  it('shows the card when there is a failure reason', () => {
+    expect(
+      showSeqeraTaskProgressCard({ Platform: 'Seqera Cloud', Status: 'FAILED' }, { failureReason: 'exit status 137' }),
+    ).toBe(true);
+  });
+
+  it('shows the card when there is progress', () => {
+    expect(showSeqeraTaskProgressCard(seqeraRun, { hasProgress: true })).toBe(true);
+  });
+
+  it('hides the card when there is neither failure nor progress', () => {
+    expect(showSeqeraTaskProgressCard(seqeraRun, { failureReason: null, hasProgress: false })).toBe(false);
+  });
+
+  it('shows the card for a terminal run that still has failure content', () => {
+    expect(
+      showSeqeraTaskProgressCard(
+        { Platform: 'Seqera Cloud', Status: 'FAILED' },
+        { failureReason: 'exit status 137', hasProgress: true },
+      ),
+    ).toBe(true);
+  });
+
+  it('hides the card for non-Seqera and missing runs', () => {
+    expect(showSeqeraTaskProgressCard(omicsRun, { hasProgress: true })).toBe(false);
+    expect(showSeqeraTaskProgressCard(null, { hasProgress: true })).toBe(false);
+  });
+});
+
+describe('showOmicsTaskProgressCard', () => {
+  it('shows the card when there is a failure reason', () => {
+    expect(
+      showOmicsTaskProgressCard({ Platform: 'AWS HealthOmics', Status: 'FAILED' }, { failureReason: 'OutOfMemory' }),
+    ).toBe(true);
+  });
+
+  it('shows the card when there are failed tasks', () => {
+    expect(showOmicsTaskProgressCard({ Platform: 'AWS HealthOmics', Status: 'FAILED' }, { failedTaskCount: 2 })).toBe(
+      true,
+    );
+  });
+
+  it('shows the card for progress on a non-terminal run', () => {
+    expect(showOmicsTaskProgressCard(omicsRun, { hasProgress: true })).toBe(true);
+  });
+
+  it('hides the card for progress on a terminal run with no failure content', () => {
+    expect(
+      showOmicsTaskProgressCard(
+        { Platform: 'AWS HealthOmics', Status: 'SUCCEEDED' },
+        { hasProgress: true, failedTaskCount: 0, failureReason: null },
+      ),
+    ).toBe(false);
+  });
+
+  it('hides the card when there is no content at all', () => {
+    expect(showOmicsTaskProgressCard(omicsRun, {})).toBe(false);
+  });
+
+  it('hides the card for non-HealthOmics and missing runs', () => {
+    expect(showOmicsTaskProgressCard(seqeraRun, { hasProgress: true })).toBe(false);
+    expect(showOmicsTaskProgressCard(null, { failureReason: 'OutOfMemory' })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Title*
Move run detail task progress card above tabs

## Type of Change*
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [x] UI/UX improvement

## Description
On the laboratory run detail page (`/labs/:labId/run/:labRunId`), the Seqera **Task Breakdown** and HealthOmics **Task Progress** / **Failed Tasks** cards previously rendered at the bottom of the **Run Details** tab.

This change moves those cards above the **Run Details** / **File Manager** tab controls so progress and failure task info is visible immediately under the page header, on both tabs. Visibility is gated with computed flags so completed runs without progress/failure content do not leave extra spacing above the tabs.

Related: EGV-229 (follow-up to the merged workflow progress bar work in #853).

## Testing*
- [ ] Open a running AWS HealthOmics run and confirm the Task Progress card appears above the Run Details / File Manager tabs (not at the bottom of Run Details).
- [ ] Switch to File Manager and confirm the progress card remains visible above the tabs.
- [ ] Open a failed HealthOmics run and confirm Failed Tasks / failure reason still appear in the top card area.
- [ ] Open a running or failed Seqera run and confirm Task Breakdown appears above the tabs.
- [ ] Open a succeeded/cancelled run with no progress/failure payload and confirm no empty gap is left above the tabs.
- [ ] Confirm Run Details content (retry, details table, failure analysis) and File Manager still behave as before.

## Impact
Front-end layout-only change on the run detail page. The card visibility predicates are extracted into `src/app/utils/run-progress-card-visibility.ts` and covered by unit tests in `test/app/utils/run-progress-card-visibility.test.ts`. No API, schema, or polling behavior changes. Progress cards are now shared across tabs instead of being scoped to Run Details.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [ ] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.
