### PR TITLE
fix: lint import order in test files generating warnings

### DIFF
--- a/packages/back-end/test/app/controllers/easy-genomics/laboratory/create-laboratory.lambda.test.ts
+++ b/packages/back-end/test/app/controllers/easy-genomics/laboratory/create-laboratory.lambda.test.ts
@@ -1,7 +1,19 @@
 import { ConditionalCheckFailedException, TransactionCanceledException } from '@aws-sdk/client-dynamodb';
+import { ResourceNotFoundException } from '@aws-sdk/client-omics';
+import {
+  DEFAULT_RUN_DETAIL_PROGRESS_POLL_INTERVAL_SECONDS,
+  DEFAULT_RUN_LIST_STATUS_POLL_INTERVAL_SECONDS,
+} from '@easy-genomics/shared-lib/src/app/utils/laboratory-run-progress-polling';
 import { APIGatewayProxyWithCognitoAuthorizerEvent, Context } from 'aws-lambda';
 
 import { handler } from '../../../../../src/app/controllers/easy-genomics/laboratory/create-laboratory.lambda';
+import { LaboratoryS3AccessService } from '../../../../../src/app/services/easy-genomics/laboratory-s3-access-service';
+import { LaboratoryService } from '../../../../../src/app/services/easy-genomics/laboratory-service';
+import { OrganizationService } from '../../../../../src/app/services/easy-genomics/organization-service';
+import { OmicsService } from '../../../../../src/app/services/omics-service';
+import { SsmService } from '../../../../../src/app/services/ssm-service';
+import { validateOrganizationAdminAccess } from '../../../../../src/app/utils/auth-utils';
+import { httpRequest } from '../../../../../src/app/utils/rest-api-utils';
 
 jest.mock('../../../../../src/app/services/easy-genomics/organization-service');
 jest.mock('../../../../../src/app/services/easy-genomics/laboratory-service');
@@ -10,19 +22,6 @@ jest.mock('../../../../../src/app/services/ssm-service');
 jest.mock('../../../../../src/app/services/omics-service');
 jest.mock('../../../../../src/app/utils/auth-utils');
 jest.mock('../../../../../src/app/utils/rest-api-utils');
-
-import { ResourceNotFoundException } from '@aws-sdk/client-omics';
-import { LaboratoryS3AccessService } from '../../../../../src/app/services/easy-genomics/laboratory-s3-access-service';
-import { LaboratoryService } from '../../../../../src/app/services/easy-genomics/laboratory-service';
-import { OrganizationService } from '../../../../../src/app/services/easy-genomics/organization-service';
-import { OmicsService } from '../../../../../src/app/services/omics-service';
-import { SsmService } from '../../../../../src/app/services/ssm-service';
-import { validateOrganizationAdminAccess } from '../../../../../src/app/utils/auth-utils';
-import { httpRequest } from '../../../../../src/app/utils/rest-api-utils';
-import {
-  DEFAULT_RUN_DETAIL_PROGRESS_POLL_INTERVAL_SECONDS,
-  DEFAULT_RUN_LIST_STATUS_POLL_INTERVAL_SECONDS,
-} from '@easy-genomics/shared-lib/src/app/utils/laboratory-run-progress-polling';
 
 describe('create-laboratory.lambda', () => {
   const ORG_ID = '00000000-0000-0000-0000-000000000001';

--- a/packages/back-end/test/app/services/easy-genomics/unified-workflow-catalog-service.test.ts
+++ b/packages/back-end/test/app/services/easy-genomics/unified-workflow-catalog-service.test.ts
@@ -1,5 +1,8 @@
 import type { WorkflowListItem } from '@aws-sdk/client-omics';
+import { LaboratoryService } from '../../../../src/app/services/easy-genomics/laboratory-service';
 import { buildUnifiedWorkflowCatalogForOrganization } from '../../../../src/app/services/easy-genomics/unified-workflow-catalog-service';
+import { OmicsService } from '../../../../src/app/services/omics-service';
+import { listAllSharedWorkflowSummaries } from '../../../../src/app/utils/omics-shared-workflow-utils';
 
 jest.mock('../../../../src/app/services/easy-genomics/laboratory-service');
 jest.mock('../../../../src/app/services/omics-service');
@@ -12,10 +15,6 @@ jest.mock('../../../../src/app/utils/rest-api-utils', () => ({
   httpRequest: jest.fn(),
   REST_API_METHOD: { GET: 'GET' },
 }));
-
-import { LaboratoryService } from '../../../../src/app/services/easy-genomics/laboratory-service';
-import { OmicsService } from '../../../../src/app/services/omics-service';
-import { listAllSharedWorkflowSummaries } from '../../../../src/app/utils/omics-shared-workflow-utils';
 
 describe('buildUnifiedWorkflowCatalogForOrganization', () => {
   const ORG_ID = 'org-001';


### PR DESCRIPTION
## fix: lint import order in test files generating warnings

## Type of Change*
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
The import order on two test files were generating the following warning, adjusted import order to avoid warning message on commit.
<img width="1512" height="139" alt="Screenshot 2026-08-06 at 9 51 45 AM" src="https://github.com/user-attachments/assets/0cbb446d-6fab-48b8-8d32-73655a474fc0" />

## Testing*
Tested manually when making this commit, no warning or other errors where shown.

## Impact
This has no impact.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [x] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.