### PR TITLE
feat: relative date timestamp

### DIFF
--- a/packages/back-end/scripts/backfill-laboratory-run-attributes.ts
+++ b/packages/back-end/scripts/backfill-laboratory-run-attributes.ts
@@ -55,7 +55,7 @@ function getFlagValue(flag: string): string | undefined {
   return undefined;
 }
 
-async function main(): Promise<void> {
+export async function main(): Promise<void> {
   const dryRun = process.argv.includes('--dry-run');
   const labFilter = getFlagValue('--lab');
 
@@ -138,7 +138,10 @@ async function main(): Promise<void> {
   if (pollStatusErrors > 0 || notifiedAtErrors > 0) process.exit(1);
 }
 
-main().catch((e) => {
-  console.error(e);
-  process.exit(1);
-});
+// Skip auto-run under Jest (JEST_WORKER_ID is set) so tests can import and await `main`.
+if (!process.env.JEST_WORKER_ID) {
+  main().catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });
+}

--- a/packages/back-end/test/scripts/backfill-laboratory-run-attributes.test.ts
+++ b/packages/back-end/test/scripts/backfill-laboratory-run-attributes.test.ts
@@ -17,22 +17,15 @@ function buildRun(overrides: Partial<LaboratoryRun> = {}): LaboratoryRun {
   };
 }
 
-async function flushAsync(): Promise<void> {
-  for (let i = 0; i < 10; i++) {
-    await new Promise<void>((resolve) => setImmediate(resolve));
-  }
-}
-
 interface ScriptRunResult {
   listAllLaboratoryRuns: jest.Mock;
   update: jest.Mock;
 }
 
 /**
- * The script has no exports — it runs `main()` as a side effect of being required, reading
- * `process.argv` at that moment. Re-running it per test therefore requires a fresh module
- * registry (so the service it imports internally picks up this call's mocked implementations)
- * rather than an exported entry point.
+ * Re-running the script per test requires a fresh module registry so the service it imports
+ * picks up this call's mocked implementations. `main` is exported and awaited (auto-run is
+ * skipped under Jest via JEST_WORKER_ID) to avoid racing a fire-and-forget side effect.
  */
 async function runScript(
   argv: string[],
@@ -51,13 +44,17 @@ async function runScript(
   LaboratoryRunService.prototype.update = update;
 
   process.argv = ['node', 'backfill-laboratory-run-attributes.ts', ...argv];
-  await import(SCRIPT_MODULE_PATH);
-  await flushAsync();
+  const { main } = await import(SCRIPT_MODULE_PATH);
+  await main();
 
   return { listAllLaboratoryRuns, update };
 }
 
 describe('backfill-laboratory-run-attributes script', () => {
+  // Each test resets modules and re-imports the script; cold starts under a full suite
+  // can exceed Jest's default 5s before main even runs.
+  jest.setTimeout(15_000);
+
   const originalArgv = process.argv;
   let exitSpy: jest.SpyInstance;
 

--- a/packages/front-end/src/app/components/EGDashboard.vue
+++ b/packages/front-end/src/app/components/EGDashboard.vue
@@ -788,8 +788,7 @@
         </template>
 
         <template #lastUpdated-data="{ row: run }">
-          <div class="text-body text-sm font-medium">{{ getDate(run.lastUpdated) }}</div>
-          <div class="text-muted text-xs">{{ getTime(run.lastUpdated) }}</div>
+          <div class="text-body text-sm font-medium">{{ formatRelativeDateTime(run.lastUpdated) }}</div>
         </template>
 
         <template #Status-data="{ row: run }">

--- a/packages/front-end/src/app/components/EGFileAnalysisHistoryTooltip.vue
+++ b/packages/front-end/src/app/components/EGFileAnalysisHistoryTooltip.vue
@@ -4,8 +4,8 @@
    * Card view: dot (+ count chip when N>1) + trailing chevron. Table view: dot + status text. Panel lists runs;
    * left opens run detail; right zone selects input files for that run.
    */
-  import { format } from 'date-fns';
   import type { LaboratoryRunUsageSummary } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/data-collections';
+  import { formatRelativeDateTime } from '@FE/utils/date-time';
 
   const props = defineProps<{
     labId: string;
@@ -62,17 +62,10 @@
     return parts;
   });
 
-  function formatRunDate(iso: string): string {
-    if (!iso) return '';
-    const d = new Date(iso);
-    if (Number.isNaN(d.getTime())) return '';
-    return format(d, 'yyyy-MM-dd');
-  }
-
   function runRowSubtitle(run: LaboratoryRunUsageSummary): string {
     const parts: string[] = [];
     if (run.WorkflowName?.trim()) parts.push(run.WorkflowName.trim());
-    const date = formatRunDate(run.RunCreatedAt);
+    const date = formatRelativeDateTime(run.RunCreatedAt);
     if (date) parts.push(date);
     const sampleNoun = run.InputFileCount === 1 ? 'file' : 'files';
     parts.push(`${run.InputFileCount} ${sampleNoun}`);

--- a/packages/front-end/src/app/components/EGLabView.vue
+++ b/packages/front-end/src/app/components/EGLabView.vue
@@ -978,8 +978,7 @@
       </template>
 
       <template #CreatedAt-data="{ row: run }">
-        <div class="text-body text-sm font-medium">{{ getDate(run.CreatedAt) }}</div>
-        <div class="text-muted">{{ getTime(run.CreatedAt) }}</div>
+        <div class="text-body text-sm font-medium">{{ getDateOrTimeIfToday(run.CreatedAt) }}</div>
       </template>
 
       <template #lastUpdated-data="{ row: run }">

--- a/packages/front-end/src/app/components/EGLabView.vue
+++ b/packages/front-end/src/app/components/EGLabView.vue
@@ -978,7 +978,7 @@
       </template>
 
       <template #CreatedAt-data="{ row: run }">
-        <div class="text-body text-sm font-medium">{{ getDateOrTimeIfToday(run.CreatedAt) }}</div>
+        <div class="text-body text-sm font-medium">{{ formatRelativeDateTime(run.CreatedAt) }}</div>
       </template>
 
       <template #lastUpdated-data="{ row: run }">
@@ -994,8 +994,7 @@
           :process-name="run.CurrentProcessName"
         />
         <template v-else>
-          <div class="text-body text-sm font-medium">{{ getDate(run.ModifiedAt) }}</div>
-          <div class="text-muted">{{ getTime(run.ModifiedAt) }}</div>
+          <div class="text-body text-sm font-medium">{{ formatRelativeDateTime(run.ModifiedAt) }}</div>
         </template>
       </template>
 

--- a/packages/front-end/src/app/components/EGSequenceCollectionsListTab.vue
+++ b/packages/front-end/src/app/components/EGSequenceCollectionsListTab.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
   import type { LaboratorySequenceCollection } from '@easy-genomics/shared-lib/src/app/types/easy-genomics/samples';
   import EGActionButton from '@FE/components/EGActionButton.vue';
+  import { formatRelativeDateTime } from '@FE/utils/date-time';
 
   const props = defineProps<{
     collections: LaboratorySequenceCollection[];
@@ -65,7 +66,7 @@
             <td class="p-3">
               <div class="font-medium">{{ c.Name }}</div>
               <div v-if="c.CreatedAt" class="text-xs text-gray-400">
-                Created {{ new Date(c.CreatedAt).toLocaleDateString() }}
+                Created {{ formatRelativeDateTime(c.CreatedAt) }}
               </div>
             </td>
             <td class="p-3">{{ c.SampleCount }}</td>

--- a/packages/front-end/src/app/utils/date-time.ts
+++ b/packages/front-end/src/app/utils/date-time.ts
@@ -1,4 +1,4 @@
-import { format, parseISO, isValid } from 'date-fns';
+import { format, parseISO, isValid, isToday } from 'date-fns';
 
 function parseAndValidateDate(input: string | null | undefined) {
   if (!input) {
@@ -44,4 +44,18 @@ export function getTime(input: string | null | undefined): string | null {
   const offset = offsetInHours >= 0 ? `+${Math.abs(offsetInHours)}` : `-${Math.abs(offsetInHours)}`;
   const formattedDate = format(date, 'hh:mm:ss a');
   return `${formattedDate} GMT${offset}`;
+}
+
+/**
+ * Return time if the date is today (local calendar day), otherwise return the date only.
+ */
+export function getDateOrTimeIfToday(input: string | null | undefined): string | null {
+  if (!input) {
+    return null;
+  }
+
+  const date = parseAndValidateDate(input);
+  if (!date) return null;
+
+  return isToday(date) ? getTime(input) : getDate(input);
 }

--- a/packages/front-end/src/app/utils/date-time.ts
+++ b/packages/front-end/src/app/utils/date-time.ts
@@ -66,7 +66,7 @@ function pluralize(count: number, singular: string, plural: string): string {
  * - older → "N year(s) ago"
  * - future → absolute date (yyyy-MM-dd)
  */
-export function getDateOrTimeIfToday(input: string | null | undefined): string | null {
+export function formatRelativeDateTime(input: string | null | undefined): string | null {
   if (!input) {
     return null;
   }

--- a/packages/front-end/src/app/utils/date-time.ts
+++ b/packages/front-end/src/app/utils/date-time.ts
@@ -1,4 +1,11 @@
-import { format, parseISO, isValid, isToday } from 'date-fns';
+import {
+  format,
+  parseISO,
+  isValid,
+  differenceInCalendarDays,
+  differenceInCalendarMonths,
+  differenceInCalendarYears,
+} from 'date-fns';
 
 function parseAndValidateDate(input: string | null | undefined) {
   if (!input) {
@@ -46,8 +53,18 @@ export function getTime(input: string | null | undefined): string | null {
   return `${formattedDate} GMT${offset}`;
 }
 
+function pluralize(count: number, singular: string, plural: string): string {
+  return count === 1 ? `1 ${singular} ago` : `${count} ${plural} ago`;
+}
+
 /**
- * Return time if the date is today (local calendar day), otherwise return the date only.
+ * Relative display for run timestamps (local calendar day boundaries):
+ * - today → time
+ * - yesterday → "Yesterday"
+ * - 2–30 days ago → "N days ago"
+ * - 1–12 months ago → "N month(s) ago"
+ * - older → "N year(s) ago"
+ * - future → absolute date (yyyy-MM-dd)
  */
 export function getDateOrTimeIfToday(input: string | null | undefined): string | null {
   if (!input) {
@@ -57,5 +74,33 @@ export function getDateOrTimeIfToday(input: string | null | undefined): string |
   const date = parseAndValidateDate(input);
   if (!date) return null;
 
-  return isToday(date) ? getTime(input) : getDate(input);
+  const now = new Date();
+  const daysAgo = differenceInCalendarDays(now, date);
+
+  // Future timestamps are unexpected for CreatedAt; show an absolute date rather than a
+  // relative label (negative day/month diffs would otherwise fall through incorrectly).
+  if (daysAgo < 0) {
+    return getDate(input);
+  }
+
+  if (daysAgo === 0) {
+    return getTime(input);
+  }
+
+  if (daysAgo === 1) {
+    return 'Yesterday';
+  }
+
+  if (daysAgo <= 30) {
+    return pluralize(daysAgo, 'day', 'days');
+  }
+
+  const monthsAgo = differenceInCalendarMonths(now, date);
+  // daysAgo > 30 implies at least one calendar month in normal cases; guard anyway.
+  if (monthsAgo <= 12) {
+    return pluralize(Math.max(1, monthsAgo), 'month', 'months');
+  }
+
+  const yearsAgo = Math.max(1, differenceInCalendarYears(now, date));
+  return pluralize(yearsAgo, 'year', 'years');
 }

--- a/packages/front-end/test/app/utils/date-time.test.ts
+++ b/packages/front-end/test/app/utils/date-time.test.ts
@@ -1,4 +1,4 @@
-import { getDate, getDateOrTimeIfToday, getTime } from '../../../src/app/utils/date-time';
+import { getDate, formatRelativeDateTime, getTime } from '../../../src/app/utils/date-time';
 
 describe('getDate', () => {
   it('formats a valid ISO date as yyyy-MM-dd in local time', () => {
@@ -25,7 +25,7 @@ describe('getTime', () => {
   });
 });
 
-describe('getDateOrTimeIfToday', () => {
+describe('formatRelativeDateTime', () => {
   // Fixed local "now": Friday 7 Aug 2026, noon — avoids depending on the machine clock.
   const NOW = new Date(2026, 7, 7, 12, 0, 0);
 
@@ -44,14 +44,14 @@ describe('getDateOrTimeIfToday', () => {
   });
 
   it('returns null for missing input', () => {
-    expect(getDateOrTimeIfToday(null)).toBeNull();
-    expect(getDateOrTimeIfToday(undefined)).toBeNull();
-    expect(getDateOrTimeIfToday('')).toBeNull();
+    expect(formatRelativeDateTime(null)).toBeNull();
+    expect(formatRelativeDateTime(undefined)).toBeNull();
+    expect(formatRelativeDateTime('')).toBeNull();
   });
 
   it('returns null for an invalid date string', () => {
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
-    expect(getDateOrTimeIfToday('not-a-date')).toBeNull();
+    expect(formatRelativeDateTime('not-a-date')).toBeNull();
     errorSpy.mockRestore();
   });
 
@@ -59,80 +59,80 @@ describe('getDateOrTimeIfToday', () => {
     it('returns the time for today at early morning and late evening', () => {
       const early = localIso(2026, 7, 7, 0, 15);
       const late = localIso(2026, 7, 7, 23, 45);
-      expect(getDateOrTimeIfToday(early)).toBe(getTime(early));
-      expect(getDateOrTimeIfToday(late)).toBe(getTime(late));
+      expect(formatRelativeDateTime(early)).toBe(getTime(early));
+      expect(formatRelativeDateTime(late)).toBe(getTime(late));
     });
 
     it('returns "Yesterday" for late evening yesterday and early morning yesterday', () => {
-      expect(getDateOrTimeIfToday(localIso(2026, 7, 6, 23, 45))).toBe('Yesterday');
-      expect(getDateOrTimeIfToday(localIso(2026, 7, 6, 0, 15))).toBe('Yesterday');
+      expect(formatRelativeDateTime(localIso(2026, 7, 6, 23, 45))).toBe('Yesterday');
+      expect(formatRelativeDateTime(localIso(2026, 7, 6, 0, 15))).toBe('Yesterday');
     });
 
     it('classifies by local calendar day after UTC serialization round-trip', () => {
       // toISOString() is UTC; classification must still use the local calendar day.
       const yesterdayLateLocal = new Date(2026, 7, 6, 23, 0, 0);
-      expect(getDateOrTimeIfToday(yesterdayLateLocal.toISOString())).toBe('Yesterday');
+      expect(formatRelativeDateTime(yesterdayLateLocal.toISOString())).toBe('Yesterday');
     });
   });
 
   describe('days ago (2–30 inclusive)', () => {
     it('returns "2 days ago" at the lower bound, regardless of time of day', () => {
-      expect(getDateOrTimeIfToday(localIso(2026, 7, 5, 0, 0))).toBe('2 days ago');
-      expect(getDateOrTimeIfToday(localIso(2026, 7, 5, 23, 59))).toBe('2 days ago');
+      expect(formatRelativeDateTime(localIso(2026, 7, 5, 0, 0))).toBe('2 days ago');
+      expect(formatRelativeDateTime(localIso(2026, 7, 5, 23, 59))).toBe('2 days ago');
     });
 
     it('returns "30 days ago" at the upper bound (prefers days over months)', () => {
       // Jul 8 is both 30 calendar days and 1 calendar month before Aug 7 — days bucket wins.
-      expect(getDateOrTimeIfToday(localIso(2026, 6, 8))).toBe('30 days ago');
+      expect(formatRelativeDateTime(localIso(2026, 6, 8))).toBe('30 days ago');
     });
 
     it('crosses a month boundary while still in the days bucket', () => {
-      expect(getDateOrTimeIfToday(localIso(2026, 6, 20))).toBe('18 days ago');
+      expect(formatRelativeDateTime(localIso(2026, 6, 20))).toBe('18 days ago');
     });
   });
 
   describe('months ago (1–12 inclusive)', () => {
     it('switches to months once past 30 calendar days', () => {
       // Jul 7 is 31 days and 1 calendar month before Aug 7.
-      expect(getDateOrTimeIfToday(localIso(2026, 6, 7))).toBe('1 month ago');
+      expect(formatRelativeDateTime(localIso(2026, 6, 7))).toBe('1 month ago');
     });
 
     it('returns "12 months ago" at the upper bound (prefers months over years)', () => {
       // Exactly one year earlier is 12 months and 1 calendar year — months bucket wins.
-      expect(getDateOrTimeIfToday(localIso(2025, 7, 7))).toBe('12 months ago');
+      expect(formatRelativeDateTime(localIso(2025, 7, 7))).toBe('12 months ago');
     });
 
     it('handles end-of-month month arithmetic', () => {
       jest.setSystemTime(new Date(2026, 2, 31, 12, 0, 0)); // Mar 31
-      expect(getDateOrTimeIfToday(localIso(2026, 0, 31))).toBe('2 months ago'); // Jan 31
-      expect(getDateOrTimeIfToday(localIso(2026, 1, 28))).toBe('1 month ago'); // Feb 28
+      expect(formatRelativeDateTime(localIso(2026, 0, 31))).toBe('2 months ago'); // Jan 31
+      expect(formatRelativeDateTime(localIso(2026, 1, 28))).toBe('1 month ago'); // Feb 28
     });
   });
 
   describe('years ago (older than 12 months)', () => {
     it('returns "1 year ago" just past the 12-month boundary', () => {
-      expect(getDateOrTimeIfToday(localIso(2025, 6, 7))).toBe('1 year ago'); // 13 months
+      expect(formatRelativeDateTime(localIso(2025, 6, 7))).toBe('1 year ago'); // 13 months
     });
 
     it('returns plural years for multi-year-old timestamps', () => {
-      expect(getDateOrTimeIfToday(localIso(2020, 7, 7))).toBe('6 years ago');
+      expect(formatRelativeDateTime(localIso(2020, 7, 7))).toBe('6 years ago');
     });
 
     it('handles a leap-day source date', () => {
-      expect(getDateOrTimeIfToday(localIso(2024, 1, 29))).toBe('2 years ago');
+      expect(formatRelativeDateTime(localIso(2024, 1, 29))).toBe('2 years ago');
     });
   });
 
   describe('calendar / year-boundary edges', () => {
     it('returns "Yesterday" across New Year (Jan 1 ← Dec 31)', () => {
       jest.setSystemTime(new Date(2026, 0, 1, 12, 0, 0));
-      expect(getDateOrTimeIfToday(localIso(2025, 11, 31, 23, 30))).toBe('Yesterday');
+      expect(formatRelativeDateTime(localIso(2025, 11, 31, 23, 30))).toBe('Yesterday');
     });
 
     it('returns an absolute date for future timestamps (does not say years ago)', () => {
       const tomorrow = localIso(2026, 7, 8);
-      expect(getDateOrTimeIfToday(tomorrow)).toBe(getDate(tomorrow));
-      expect(getDateOrTimeIfToday(tomorrow)).not.toMatch(/ago$/);
+      expect(formatRelativeDateTime(tomorrow)).toBe(getDate(tomorrow));
+      expect(formatRelativeDateTime(tomorrow)).not.toMatch(/ago$/);
     });
   });
 });

--- a/packages/front-end/test/app/utils/date-time.test.ts
+++ b/packages/front-end/test/app/utils/date-time.test.ts
@@ -26,6 +26,23 @@ describe('getTime', () => {
 });
 
 describe('getDateOrTimeIfToday', () => {
+  // Fixed local "now": Friday 7 Aug 2026, noon — avoids depending on the machine clock.
+  const NOW = new Date(2026, 7, 7, 12, 0, 0);
+
+  /** Build an ISO string from local calendar components (not UTC), so day boundaries are stable. */
+  function localIso(year: number, monthIndex: number, day: number, hour = 12, minute = 0): string {
+    return new Date(year, monthIndex, day, hour, minute, 0).toISOString();
+  }
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it('returns null for missing input', () => {
     expect(getDateOrTimeIfToday(null)).toBeNull();
     expect(getDateOrTimeIfToday(undefined)).toBeNull();
@@ -38,18 +55,84 @@ describe('getDateOrTimeIfToday', () => {
     errorSpy.mockRestore();
   });
 
-  it('returns the time when the date is today (local calendar day)', () => {
-    const todayLocal = new Date();
-    todayLocal.setHours(12, 30, 45, 0);
-    const iso = todayLocal.toISOString();
+  describe('today / yesterday (local calendar day, not 24h window)', () => {
+    it('returns the time for today at early morning and late evening', () => {
+      const early = localIso(2026, 7, 7, 0, 15);
+      const late = localIso(2026, 7, 7, 23, 45);
+      expect(getDateOrTimeIfToday(early)).toBe(getTime(early));
+      expect(getDateOrTimeIfToday(late)).toBe(getTime(late));
+    });
 
-    expect(getDateOrTimeIfToday(iso)).toBe(getTime(iso));
+    it('returns "Yesterday" for late evening yesterday and early morning yesterday', () => {
+      expect(getDateOrTimeIfToday(localIso(2026, 7, 6, 23, 45))).toBe('Yesterday');
+      expect(getDateOrTimeIfToday(localIso(2026, 7, 6, 0, 15))).toBe('Yesterday');
+    });
+
+    it('classifies by local calendar day after UTC serialization round-trip', () => {
+      // toISOString() is UTC; classification must still use the local calendar day.
+      const yesterdayLateLocal = new Date(2026, 7, 6, 23, 0, 0);
+      expect(getDateOrTimeIfToday(yesterdayLateLocal.toISOString())).toBe('Yesterday');
+    });
   });
 
-  it('returns the date when the date is not today', () => {
-    const iso = '2020-06-15T12:00:00.000Z';
+  describe('days ago (2–30 inclusive)', () => {
+    it('returns "2 days ago" at the lower bound, regardless of time of day', () => {
+      expect(getDateOrTimeIfToday(localIso(2026, 7, 5, 0, 0))).toBe('2 days ago');
+      expect(getDateOrTimeIfToday(localIso(2026, 7, 5, 23, 59))).toBe('2 days ago');
+    });
 
-    expect(getDateOrTimeIfToday(iso)).toBe(getDate(iso));
-    expect(getDateOrTimeIfToday(iso)).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    it('returns "30 days ago" at the upper bound (prefers days over months)', () => {
+      // Jul 8 is both 30 calendar days and 1 calendar month before Aug 7 — days bucket wins.
+      expect(getDateOrTimeIfToday(localIso(2026, 6, 8))).toBe('30 days ago');
+    });
+
+    it('crosses a month boundary while still in the days bucket', () => {
+      expect(getDateOrTimeIfToday(localIso(2026, 6, 20))).toBe('18 days ago');
+    });
+  });
+
+  describe('months ago (1–12 inclusive)', () => {
+    it('switches to months once past 30 calendar days', () => {
+      // Jul 7 is 31 days and 1 calendar month before Aug 7.
+      expect(getDateOrTimeIfToday(localIso(2026, 6, 7))).toBe('1 month ago');
+    });
+
+    it('returns "12 months ago" at the upper bound (prefers months over years)', () => {
+      // Exactly one year earlier is 12 months and 1 calendar year — months bucket wins.
+      expect(getDateOrTimeIfToday(localIso(2025, 7, 7))).toBe('12 months ago');
+    });
+
+    it('handles end-of-month month arithmetic', () => {
+      jest.setSystemTime(new Date(2026, 2, 31, 12, 0, 0)); // Mar 31
+      expect(getDateOrTimeIfToday(localIso(2026, 0, 31))).toBe('2 months ago'); // Jan 31
+      expect(getDateOrTimeIfToday(localIso(2026, 1, 28))).toBe('1 month ago'); // Feb 28
+    });
+  });
+
+  describe('years ago (older than 12 months)', () => {
+    it('returns "1 year ago" just past the 12-month boundary', () => {
+      expect(getDateOrTimeIfToday(localIso(2025, 6, 7))).toBe('1 year ago'); // 13 months
+    });
+
+    it('returns plural years for multi-year-old timestamps', () => {
+      expect(getDateOrTimeIfToday(localIso(2020, 7, 7))).toBe('6 years ago');
+    });
+
+    it('handles a leap-day source date', () => {
+      expect(getDateOrTimeIfToday(localIso(2024, 1, 29))).toBe('2 years ago');
+    });
+  });
+
+  describe('calendar / year-boundary edges', () => {
+    it('returns "Yesterday" across New Year (Jan 1 ← Dec 31)', () => {
+      jest.setSystemTime(new Date(2026, 0, 1, 12, 0, 0));
+      expect(getDateOrTimeIfToday(localIso(2025, 11, 31, 23, 30))).toBe('Yesterday');
+    });
+
+    it('returns an absolute date for future timestamps (does not say years ago)', () => {
+      const tomorrow = localIso(2026, 7, 8);
+      expect(getDateOrTimeIfToday(tomorrow)).toBe(getDate(tomorrow));
+      expect(getDateOrTimeIfToday(tomorrow)).not.toMatch(/ago$/);
+    });
   });
 });

--- a/packages/front-end/test/app/utils/date-time.test.ts
+++ b/packages/front-end/test/app/utils/date-time.test.ts
@@ -1,0 +1,55 @@
+import { getDate, getDateOrTimeIfToday, getTime } from '../../../src/app/utils/date-time';
+
+describe('getDate', () => {
+  it('formats a valid ISO date as yyyy-MM-dd in local time', () => {
+    const localNoon = new Date(2021, 0, 1, 12, 0, 0);
+    expect(getDate(localNoon.toISOString())).toBe('2021-01-01');
+  });
+
+  it('returns null for missing input', () => {
+    expect(getDate(null)).toBeNull();
+    expect(getDate(undefined)).toBeNull();
+    expect(getDate('')).toBeNull();
+  });
+});
+
+describe('getTime', () => {
+  it('formats a valid ISO date with local time and GMT offset', () => {
+    expect(getTime('2021-01-01T09:38:13.000Z')).toMatch(/^\d{2}:\d{2}:\d{2} (AM|PM) GMT[+-]\d+(\.\d+)?$/);
+  });
+
+  it('returns null for missing input', () => {
+    expect(getTime(null)).toBeNull();
+    expect(getTime(undefined)).toBeNull();
+    expect(getTime('')).toBeNull();
+  });
+});
+
+describe('getDateOrTimeIfToday', () => {
+  it('returns null for missing input', () => {
+    expect(getDateOrTimeIfToday(null)).toBeNull();
+    expect(getDateOrTimeIfToday(undefined)).toBeNull();
+    expect(getDateOrTimeIfToday('')).toBeNull();
+  });
+
+  it('returns null for an invalid date string', () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    expect(getDateOrTimeIfToday('not-a-date')).toBeNull();
+    errorSpy.mockRestore();
+  });
+
+  it('returns the time when the date is today (local calendar day)', () => {
+    const todayLocal = new Date();
+    todayLocal.setHours(12, 30, 45, 0);
+    const iso = todayLocal.toISOString();
+
+    expect(getDateOrTimeIfToday(iso)).toBe(getTime(iso));
+  });
+
+  it('returns the date when the date is not today', () => {
+    const iso = '2020-06-15T12:00:00.000Z';
+
+    expect(getDateOrTimeIfToday(iso)).toBe(getDate(iso));
+    expect(getDateOrTimeIfToday(iso)).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+});


### PR DESCRIPTION
## Title*
Show relative timestamps for pipeline runs and related list dates (EGV-247)

## Type of Change*
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [x] UI/UX improvement

## Description
Adds a shared `formatRelativeDateTime` helper so list/scan views show timestamps that are easier to scan:

- **Today** → local time (with GMT offset)
- **Yesterday** → `Yesterday`
- **2–30 days ago** → `N days ago`
- **1–12 months ago** → `N month(s) ago`
- **Older** → `N year(s) ago`
- **Future** → absolute `yyyy-MM-dd` (avoids incorrect relative labels)

Applied in:

- Lab Pipeline Runs table — Created At and Last Updated (`EGLabView.vue`)
- Dashboard Recent Runs — Last Updated (`EGDashboard.vue`)
- File analysis history tooltip — run created date (`EGFileAnalysisHistoryTooltip.vue`)
- Sequence collections list — Created subtitle (`EGSequenceCollectionsListTab.vue`)

Also stabilizes a flaky back-end test for `backfill-laboratory-run-attributes` by exporting and awaiting `main()` under Jest instead of racing a fire-and-forget import side effect.

Related: EGV-247

## Testing*
- Added unit tests in `packages/front-end/test/app/utils/date-time.test.ts` covering today/yesterday, day/month/year bucket boundaries, end-of-month math, New Year, leap day, UTC round-trip, and future timestamps (fake timers with a fixed local “now”).
- Ran `pnpm exec jest test/app/utils/date-time.test.ts` in `packages/front-end` — passing.
- Updated `backfill-laboratory-run-attributes` script tests to await `main()` and raised suite timeout; re-ran those tests — passing.

## Impact
- Timestamp display in the listed UI surfaces changes from absolute date+time (or locale date) to relative labels.
- Run detail pages are unchanged and still show precise absolute timestamps.
- No new dependencies (`date-fns` already in use).
- Back-end script behavior for CLI usage is unchanged; auto-run is skipped only when `JEST_WORKER_ID` is set.

## Additional Information
Relative buckets use **local calendar** day/month/year differences (`differenceInCalendar*`), not rolling 24-hour windows. At overlapping boundaries (e.g. exactly 30 days vs 1 month, exactly 12 months vs 1 year), the finer-grained bucket wins.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [x] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.