### PR TITLE
fix: flaky 5s timeout in backfill-laboratory-run-attributes test suite

### DIFF
--- a/packages/back-end/test/scripts/backfill-laboratory-run-attributes.test.ts
+++ b/packages/back-end/test/scripts/backfill-laboratory-run-attributes.test.ts
@@ -58,6 +58,11 @@ async function runScript(
 }
 
 describe('backfill-laboratory-run-attributes script', () => {
+  // Every test here calls jest.resetModules() and re-imports the script and its whole dependency
+  // tree via runScript(). That's inherently heavier than a typical unit test, and under CI's
+  // parallel Jest workers the resulting CPU contention has pushed it past the 5s default.
+  jest.setTimeout(15000);
+
   const originalArgv = process.argv;
   let exitSpy: jest.SpyInstance;
 


### PR DESCRIPTION
## Type of Change*
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
`test/scripts/backfill-laboratory-run-attributes.test.ts` failed in CI (`Build & Deploy Back-End`, run [31188428827](https://github.com/dept/easy-genomics/actions/runs/31188428827/job/92898789783) on `development`) with `Exceeded timeout of 5000 ms for a test.` on the first test in the file.

Every test in this suite calls `jest.resetModules()` and re-imports the backfill script and its whole dependency tree via the local `runScript()` helper — inherently heavier than a typical unit test. Under CI's parallel Jest workers, the resulting CPU contention pushed that cost past the 5s Jest default. Locally, in isolation, the same test takes ~1.7s, confirming the test logic itself is correct and this is a CI-only resource-contention flake, not a regression.

Fix: added `jest.setTimeout(15000)` for the suite (`describe('backfill-laboratory-run-attributes script', ...)`) instead of removing the test, since the coverage is legitimate and the test isn't wrong — it just needs headroom under load.

## Testing*
- Ran the file in isolation: `pnpm exec jest test/scripts/backfill-laboratory-run-attributes.test.ts --verbose` — 9/9 passed.
- Ran the full back-end suite: `pnpm test` in `packages/back-end` — 109/109 suites, 798/798 tests passed.
- Ran `pnpm lint` in `packages/back-end` — no errors (one pre-existing, unrelated import-order warning in a different file).

## Impact
Test-only change — no production code touched. No new dependencies, no schema/infra changes, no behavior change to the backfill script itself.

## Additional Information
None.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary. *(no new tests — existing test's timeout increased)*
- [ ] Documentation has been updated accordingly. *(N/A — no user-facing or dev-doc changes)*
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.