### PR TITLE
fix: persist run status before cost capture so large Omics runs don't hang at RUNNING

### DIFF
--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/process-update-laboratory-run.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/process-update-laboratory-run.lambda.ts
@@ -42,11 +42,30 @@ const ssmService = new SsmService();
 
 /**
  * Best-effort platform cost capture. Must never break the status-check pipeline.
+ *
+ * HealthOmics cost uses paginated ListRunTasks; large runs can take well over the
+ * Lambda timeout (observed: 5k+ tasks / ~2min). Cap wait time so status/notify
+ * writes always complete; uncaptured cost can be healed by process-sync-run-costs.
  */
+const COST_CAPTURE_BUDGET_MS = 8_000;
+
 async function safeCaptureRunCost(run: LaboratoryRun): Promise<LaboratoryRun['RunCostOutcome'] | undefined> {
   if (run.RunCostOutcome?.CostCapturedAt) return run.RunCostOutcome;
   try {
-    return await captureRunCostOutcome(run);
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    const result = await Promise.race([
+      captureRunCostOutcome(run),
+      new Promise<undefined>((resolve) => {
+        timeoutId = setTimeout(() => {
+          console.warn(
+            `Cost capture timed out after ${COST_CAPTURE_BUDGET_MS}ms for RunId=${run.RunId} (continuing without cost)`,
+          );
+          resolve(undefined);
+        }, COST_CAPTURE_BUDGET_MS);
+      }),
+    ]);
+    if (timeoutId) clearTimeout(timeoutId);
+    return result;
   } catch (err) {
     console.warn(`Failed to capture run cost for RunId=${run.RunId} (continuing):`, err);
     return undefined;
@@ -167,7 +186,13 @@ async function safePropagateExpiresAt(
   }
 }
 
-export const handler: Handler = async (event: SQSEvent): Promise<APIGatewayProxyResult> => {
+export const handler: Handler = async (event: SQSEvent, context): Promise<APIGatewayProxyResult> => {
+  // Cost capture may leave paginated Omics ListRunTasks requests in flight after we
+  // abandon them via Promise.race; do not wait for the empty event loop or those
+  // requests will hold the invocation until the Lambda timeout and redrive SQS.
+  if (context && typeof context === 'object') {
+    (context as { callbackWaitsForEmptyEventLoop?: boolean }).callbackWaitsForEmptyEventLoop = false;
+  }
   console.log('EVENT: \n' + JSON.stringify(event, null, 2));
   try {
     const sqsRecords: SQSRecord[] = event.Records;
@@ -290,12 +315,12 @@ export async function processStatusCheckEvent(operation: SnsProcessingOperation,
         }
       }
 
-      const costOutcome = missingCost ? await safeCaptureRunCost(existingRun) : undefined;
-
       const backfilledExpiresAt = missingExpiresAt
         ? calculateExpiresAtEpochSeconds(new Date(terminalAtIso), retentionMonths)
         : undefined;
 
+      // Persist terminal metadata / duration before cost capture so a slow
+      // ListRunTasks cannot block notification or leave ExpiresAt unset.
       const updated = await laboratoryRunService.update({
         ...existingRun,
         ...(missingTerminalAt ? { TerminalAt: terminalAtIso } : {}),
@@ -303,7 +328,6 @@ export async function processStatusCheckEvent(operation: SnsProcessingOperation,
         ...(snapshot?.durationSeconds != null && existingRun.RunDurationSeconds == null
           ? { RunDurationSeconds: snapshot.durationSeconds }
           : {}),
-        ...(costOutcome ? { RunCostOutcome: costOutcome } : {}),
         ModifiedAt: now.toISOString(),
         ModifiedBy: 'Status Check',
       });
@@ -319,6 +343,18 @@ export async function processStatusCheckEvent(operation: SnsProcessingOperation,
         });
         if (published) {
           await publishForNotificationWithCompensation(notifiedRun);
+        }
+      }
+
+      if (missingCost) {
+        const costOutcome = await safeCaptureRunCost(updated);
+        if (costOutcome) {
+          await laboratoryRunService.update({
+            ...updated,
+            RunCostOutcome: costOutcome,
+            ModifiedAt: new Date().toISOString(),
+            ModifiedBy: 'Status Check',
+          });
         }
       }
 
@@ -353,34 +389,38 @@ export async function processStatusCheckEvent(operation: SnsProcessingOperation,
           ? calculateExpiresAtEpochSeconds(new Date(terminalAtIso), retentionMonths)
           : undefined;
 
-      const costOutcome =
-        nextStatusTerminal && existingRun.RunCostOutcome?.CostCapturedAt == null
-          ? await safeCaptureRunCost(existingRun)
-          : undefined;
+      const { update: progressUpdate, remove: progressRemove } = buildProgressUpdate(
+        existingRun,
+        snapshot.progress,
+        nextStatusTerminal,
+      );
 
-      const progressUpdate = buildProgressUpdate(existingRun, snapshot.progress);
-
-      laboratoryRun = await laboratoryRunService.update({
-        ...progressUpdate,
-        Status: newStatusNormalized,
-        ...(shouldSetTerminalAt ? { TerminalAt: terminalAtIso } : {}),
-        ...(newExpiresAt !== undefined ? { ExpiresAt: newExpiresAt } : {}),
-        ...(snapshot.durationSeconds != null && existingRun.RunDurationSeconds == null
-          ? { RunDurationSeconds: snapshot.durationSeconds }
-          : {}),
-        ...(costOutcome ? { RunCostOutcome: costOutcome } : {}),
-        ...(newStatusNormalized === 'FAILED' && snapshot.failureReason && existingRun.FailureReason == null
-          ? { FailureReason: snapshot.failureReason }
-          : {}),
-        ...(newStatusNormalized === 'FAILED' && snapshot.statusMessage && existingRun.FailureReason == null
-          ? { FailureStatusMessage: snapshot.statusMessage }
-          : {}),
-        ...(newStatusNormalized === 'FAILED' && snapshot.errorReport && existingRun.FailureReason == null
-          ? { FailureErrorReport: snapshot.errorReport }
-          : {}),
-        ModifiedAt: now.toISOString(),
-        ModifiedBy: 'Status Check',
-      });
+      // Write status (and terminal metadata) before cost capture. Large Omics runs
+      // can spend minutes in ListRunTasks; blocking here left Status stuck at RUNNING
+      // until the Lambda timed out and SQS retried forever.
+      laboratoryRun = await laboratoryRunService.updateWithAttributeRemoval(
+        {
+          ...progressUpdate,
+          Status: newStatusNormalized,
+          ...(shouldSetTerminalAt ? { TerminalAt: terminalAtIso } : {}),
+          ...(newExpiresAt !== undefined ? { ExpiresAt: newExpiresAt } : {}),
+          ...(snapshot.durationSeconds != null && existingRun.RunDurationSeconds == null
+            ? { RunDurationSeconds: snapshot.durationSeconds }
+            : {}),
+          ...(newStatusNormalized === 'FAILED' && snapshot.failureReason && existingRun.FailureReason == null
+            ? { FailureReason: snapshot.failureReason }
+            : {}),
+          ...(newStatusNormalized === 'FAILED' && snapshot.statusMessage && existingRun.FailureReason == null
+            ? { FailureStatusMessage: snapshot.statusMessage }
+            : {}),
+          ...(newStatusNormalized === 'FAILED' && snapshot.errorReport && existingRun.FailureReason == null
+            ? { FailureErrorReport: snapshot.errorReport }
+            : {}),
+          ModifiedAt: now.toISOString(),
+          ModifiedBy: 'Status Check',
+        },
+        progressRemove,
+      );
       await safePropagateExpiresAt(laboratory, laboratoryRun, newExpiresAt);
       if (newStatusNormalized === 'FAILED' && existingRun.FailureOwner == null) {
         await safePublishForClassification(laboratoryRun);
@@ -394,6 +434,18 @@ export async function processStatusCheckEvent(operation: SnsProcessingOperation,
         });
         if (published) {
           await publishForNotificationWithCompensation(notifiedRun);
+        }
+      }
+
+      if (nextStatusTerminal && existingRun.RunCostOutcome?.CostCapturedAt == null) {
+        const costOutcome = await safeCaptureRunCost(laboratoryRun);
+        if (costOutcome) {
+          laboratoryRun = await laboratoryRunService.update({
+            ...laboratoryRun,
+            RunCostOutcome: costOutcome,
+            ModifiedAt: new Date().toISOString(),
+            ModifiedBy: 'Status Check',
+          });
         }
       }
     } else if (

--- a/packages/back-end/test/app/controllers/easy-genomics/laboratory/run/process-update-laboratory-run.lambda.test.ts
+++ b/packages/back-end/test/app/controllers/easy-genomics/laboratory/run/process-update-laboratory-run.lambda.test.ts
@@ -766,9 +766,15 @@ describe('process-update-laboratory-run.lambda', () => {
     await processStatusCheckEvent('UPDATE', { RunId: 'run-1' } as any);
 
     expect(captureRunCostOutcome).toHaveBeenCalled();
-    expect(mockUpdateRun).toHaveBeenCalledWith(
+    // Status is written first; cost is a follow-up update when capture succeeds.
+    expect(mockUpdateRun).toHaveBeenNthCalledWith(
+      1,
       expect.objectContaining({
         Status: 'SUCCEEDED',
+      }),
+    );
+    expect(mockUpdateRun).toHaveBeenCalledWith(
+      expect.objectContaining({
         RunCostOutcome: expect.objectContaining({ ActualComputeCostUsd: 4.2 }),
       }),
     );
@@ -792,8 +798,9 @@ describe('process-update-laboratory-run.lambda', () => {
       expect.objectContaining({
         Status: 'SUCCEEDED',
       }),
+      expect.any(Array),
     );
-    expect(mockUpdateRun).toHaveBeenCalledWith(expect.not.objectContaining({ RunCostOutcome: expect.anything() }));
+    expect(mockUpdateRun).not.toHaveBeenCalledWith(expect.objectContaining({ RunCostOutcome: expect.anything() }));
   });
 
   it('backfills RunCostOutcome for already-terminal runs missing cost', async () => {
@@ -817,6 +824,7 @@ describe('process-update-laboratory-run.lambda', () => {
     await processStatusCheckEvent('UPDATE', { RunId: 'run-1' } as any);
 
     expect(captureRunCostOutcome).toHaveBeenCalled();
+    // Terminal metadata update first, then cost-only update.
     expect(mockUpdateRun).toHaveBeenCalledWith(
       expect.objectContaining({
         RunCostOutcome: expect.objectContaining({ ActualComputeCostUsd: 9 }),

--- a/packages/back-end/test/scripts/backfill-laboratory-run-attributes.test.ts
+++ b/packages/back-end/test/scripts/backfill-laboratory-run-attributes.test.ts
@@ -57,9 +57,10 @@ async function runScript(
 
 describe('backfill-laboratory-run-attributes script', () => {
   // Every test here calls jest.resetModules() and re-imports the script and its whole dependency
-  // tree via runScript(). That's inherently heavier than a typical unit test, and under CI's
-  // parallel Jest workers the resulting CPU contention has pushed it past the 5s default.
-  jest.setTimeout(15000);
+  // tree via runScript(). That's inherently heavier than a typical unit test, and under a full
+  // parallel Jest run the resulting CPU contention has pushed individual cases past both the
+  // 5s default and a later 15s bump (suite wall time observed >3min for this file alone).
+  jest.setTimeout(60000);
 
   const originalArgv = process.argv;
   let exitSpy: jest.SpyInstance;

--- a/packages/front-end/env.nuxt.config.ts
+++ b/packages/front-end/env.nuxt.config.ts
@@ -23,7 +23,9 @@ export function loadNuxtSettings() {
 
   const localEnvPath = path.join(configDir, '.env.nuxt.local');
   if (fs.existsSync(localEnvPath)) {
-    dotenv.config({ path: localEnvPath });
+    // dotenv skips keys that are already set unless override is true. Without
+    // this, .env.nuxt.local cannot replace Cognito IDs rewritten by nuxt-load-settings.
+    dotenv.config({ path: localEnvPath, override: true });
   }
 
   // Env var toggle: use local back-end without renaming/editing .env.nuxt.local


### PR DESCRIPTION
## Title*
Fix large HealthOmics runs stuck at RUNNING when status-check cost capture times out

## Type of Change*
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Omics runs that finish on the platform could remain `RUNNING` in Easy Genomics because `process-update-laboratory-run` awaited HealthOmics cost capture (`listAllRunTasks`) **before** writing the terminal status to DynamoDB.

For large runs (observed: 5,000+ tasks, ~2 minutes to page `ListRunTasks`), that work exceeds the Lambda’s 30s timeout. The invocation fails, SQS redrives the same message, and DynamoDB never gets `COMPLETED`/`FAILED`/etc.—so the UI keeps polling and shows the run as in progress.

This change:
- Persists status / terminal metadata / notification side effects **before** cost capture (status-change and backfill paths)
- Time-boxes cost capture to 8s (`Promise.race`) so it cannot block the pipeline
- Sets `callbackWaitsForEmptyEventLoop = false` so abandoned in-flight `ListRunTasks` requests do not hold the invoke open until timeout and redrive SQS
- Updates unit tests for the status-then-cost write order
- Bumps the flaky `backfill-laboratory-run-attributes` suite timeout (resetModules under full parallel runs)
- Allows `.env.nuxt.local` to override keys already loaded by `nuxt-load-settings` (`dotenv` `override: true`) for local FE config

Related: EGV-244

## Testing*
- Updated `process-update-laboratory-run.lambda.test.ts` for status-first then cost follow-up update; cost-failure path still swallows errors and writes status
- Re-ran `process-update-laboratory-run` and `backfill-laboratory-run-attributes` Jest suites locally
- Runtime verification against quality: local invoke of the fixed handler wrote `Status=COMPLETED` for a stuck Omics run; subsequent status-check reported `runsToProcessCount: 0`

## Impact
- Terminal status updates no longer depend on finishing a full Omics task census
- Large runs may temporarily lack task-based `RunCostOutcome` if capture exceeds 8s (manual `backfill-run-cost-outcomes` or later capture attempts can fill it; daily `process-sync-run-costs` is Cost Explorer `BilledCost`, not this path)
- Progress reporting while a run is still non-terminal is unchanged (separate `listAllRunTasks` path; not under the 8s budget)
- Requires deploying `process-update-laboratory-run` for the fix to apply in AWS; local SQS env alone only affects enqueueing

## Additional Information
- Branch also includes a small front-end local-env override fix and a test-timeout bump unrelated to the cost/status race—call out in review if you’d rather split those
- Quality had built up a large backlog on `laboratory-run-update-queue.fifo` because timed-out invocations kept redriving the same large-run messages. After this consumer is deployed, those messages should be able to persist terminal status and complete successfully so SQS can delete them instead of retrying forever

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [ ] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.