### PR TITLE
fix: link header logo home and show current lab in labs nav

### DIFF
--- a/packages/front-end/src/app/components/EGHeader.vue
+++ b/packages/front-end/src/app/components/EGHeader.vue
@@ -12,15 +12,37 @@
 
   const userStore = useUserStore();
   const orgsStore = useOrgsStore();
+  const labsStore = useLabsStore();
 
   const { signOutAndRedirect } = useAuth();
   const $router = useRouter();
+  const $route = useRoute();
+  const homePath = '/';
   const labsPath = '/labs';
   const orgsPath = '/orgs';
 
   function isSubpath(url: string) {
     return $router.currentRoute.value.path.includes(url);
   }
+
+  const currentLabId = computed<string | null>(() => {
+    const labId = $route.params.labId;
+    return typeof labId === 'string' && labId.length > 0 ? labId : null;
+  });
+
+  const currentLabName = computed<string | null>(() => {
+    if (!currentLabId.value) {
+      return null;
+    }
+    return labsStore.labs[currentLabId.value]?.Name ?? null;
+  });
+
+  const labsNavLabel = computed<string>(() => {
+    if (currentLabName.value) {
+      return `Labs · ${currentLabName.value}`;
+    }
+    return 'Labs';
+  });
 
   const acctDropdownIsOpen = ref<boolean>(false);
 
@@ -171,20 +193,27 @@
   <header class="flex flex-row items-center px-8">
     <div class="header-container" :class="{ 'flex w-full flex-row items-center justify-between': props.isAuthed }">
       <template v-if="props.isAuthed">
-        <img class="mr-2 w-[140px]" src="@/assets/images/easy-genomics-logo.svg" alt="EasyGenomics logo" />
+        <NuxtLink
+          :to="homePath"
+          class="focus-visible:outline-primary-500 mr-2 rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
+          aria-label="Easy Genomics home"
+        >
+          <img class="w-[140px]" src="@/assets/images/easy-genomics-logo.svg" alt="EasyGenomics logo" />
+        </NuxtLink>
 
-        <div class="flex items-center gap-4">
-          <nav aria-label="Primary" class="flex items-center gap-4">
+        <div class="flex min-w-0 items-center gap-4">
+          <nav aria-label="Primary" class="flex min-w-0 items-center gap-4">
             <ULink
               v-if="!userStore.isSuperuser"
               :to="labsPath"
               :aria-current="isSubpath(labsPath) ? 'page' : undefined"
+              :aria-label="currentLabName ? `Labs, currently viewing ${currentLabName}` : 'Labs'"
               inactive-class="text-body"
               active-class="text-primary-dark bg-primary-muted"
               :class="isSubpath(labsPath) ? 'text-primary-dark bg-primary-muted' : ''"
-              class="ULink text-body focus-visible:outline-primary-500 flex h-[30px] items-center justify-center whitespace-nowrap rounded-xl px-4 py-1 font-serif text-sm tracking-normal focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
+              class="ULink text-body focus-visible:outline-primary-500 flex h-[30px] max-w-[min(100%,18rem)] items-center justify-center rounded-xl px-4 py-1 font-serif text-sm tracking-normal focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
             >
-              Labs
+              <span class="truncate">{{ labsNavLabel }}</span>
             </ULink>
             <ULink
               v-if="userStore.canManageAnyOrgs()"


### PR DESCRIPTION
## fix: link header logo home and show current lab in labs nav

## Type of Change*
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
- Make the Easy Genomics logo navigate to `/` (same home redirect as the lab dashboard / most recent lab).
- When viewing a lab, show `Labs · {Lab Name}` in the top-right Labs control; keep plain `Labs` outside lab context.
- Truncate long lab names so the header pill does not overflow.

## Testing*
- While signed in on a lab page, click the logo → lands on that lab’s Dashboard (or most recent lab dashboard via `/`).
- On a lab page, Labs control shows `Labs · {current lab name}` and still links to `/labs`.
- On `/labs`, orgs, or profile, Labs control shows only `Labs`.
- Long lab names truncate in the pill without breaking the header layout.
- Unauthenticated header logo remains non-clickable.

## Impact
Only impacts app header navigation.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [x] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.