### PR TITLE
feat: reorder pipeline runs table columns

### DIFF
--- a/packages/front-end/src/app/components/EGDashboard.vue
+++ b/packages/front-end/src/app/components/EGDashboard.vue
@@ -352,6 +352,7 @@
   const recentRunsTableColumns = [
     { key: 'RunName', label: 'Run Name', sortable: true },
     { key: 'WorkflowName', label: 'Workflow', sortable: true },
+    { key: 'CreatedAt', label: 'Created', sortable: true },
     { key: 'lastUpdated', label: 'Last Updated', sortable: true },
     { key: 'Status', label: 'Status', sortable: true },
     { key: 'actions', label: 'Actions' },
@@ -381,6 +382,7 @@
 
     return [...items].sort((a, b) => {
       if (column === 'lastUpdated') return (toSortableTime(a.lastUpdated) - toSortableTime(b.lastUpdated)) * dir;
+      if (column === 'CreatedAt') return (toSortableTime(a.CreatedAt) - toSortableTime(b.CreatedAt)) * dir;
       if (column === 'RunName') return toSortableString(a.RunName).localeCompare(toSortableString(b.RunName)) * dir;
       if (column === 'WorkflowName')
         return toSortableString(a.WorkflowName).localeCompare(toSortableString(b.WorkflowName)) * dir;
@@ -789,6 +791,11 @@
 
         <template #WorkflowName-data="{ row: run }">
           <div class="text-body text-sm font-medium">{{ run.WorkflowName || '—' }}</div>
+        </template>
+
+        <template #CreatedAt-data="{ row: run }">
+          <div class="text-body text-sm font-medium">{{ getDate(run.CreatedAt) }}</div>
+          <div class="text-muted text-xs">{{ getTime(run.CreatedAt) }}</div>
         </template>
 
         <template #lastUpdated-data="{ row: run }">

--- a/packages/front-end/src/app/components/EGLabView.vue
+++ b/packages/front-end/src/app/components/EGLabView.vue
@@ -265,10 +265,10 @@
 
   const runsTableColumns = [
     { key: 'RunName', label: 'Run Name', sortable: true },
+    { key: 'WorkflowName', label: 'Workflow name', sortable: true },
     { key: 'CreatedAt', label: 'Created At', sortable: true },
     { key: 'lastUpdated', label: 'Last Updated', sortable: true },
     { key: 'Status', label: 'Status', sortable: true },
-    { key: 'WorkflowName', label: 'Workflow name', sortable: true },
     { key: 'WorkflowVersionName', label: 'Workflow version', sortable: true },
     { key: 'Owner', label: 'Owner', sortable: true },
     { key: 'actions', label: 'Actions' },


### PR DESCRIPTION
## feat: reorder pipeline runs table columns

## Type of Change*
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
- Reorder pipeline runs table columns to: run name, workflow name, created, progress (last updated), then status.
- Apply the same order on the dashboard recent runs table and the Pipeline Runs page; remaining columns are unchanged.
- Add a Created column on the dashboard so that table can follow the same order.

## Testing*
- Open a lab dashboard and confirm recent runs columns are: Run Name, Workflow, Created, Last Updated, Status, Actions.
- Open the Pipeline Runs tab and confirm columns are: Run Name, Workflow name, Created At, Last Updated, Status, Workflow version, Owner, Actions.
- Confirm Created and Last Updated still sort correctly on both tables.
- Confirm in-progress runs still show the progress bar in the Last Updated column on the Pipeline Runs page.

## Impact
This only impacts pipeline runs tables in dashboard and pipeline runs page.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [x] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.