### PR TITLE
fix: keep long run descriptions aligned in details and review

### DIFF
--- a/packages/front-end/src/app/components/EGRunCostRow.vue
+++ b/packages/front-end/src/app/components/EGRunCostRow.vue
@@ -17,8 +17,8 @@
       estimate: null,
       labRun: null,
       loading: false,
-      labelClass: 'w-48 text-black',
-      valueClass: 'text-muted text-left',
+      labelClass: 'w-48 shrink-0 text-black',
+      valueClass: 'min-w-0 flex-1 break-words text-muted text-left',
     },
   );
 

--- a/packages/front-end/src/app/components/EGRunPipelineFormReview.vue
+++ b/packages/front-end/src/app/components/EGRunPipelineFormReview.vue
@@ -191,20 +191,22 @@
     <section class="stroke-light flex flex-col bg-white">
       <dl>
         <div class="text-md flex border-b px-4 py-4">
-          <dt class="w-48 text-black">Pipeline</dt>
-          <dd class="text-muted text-left">{{ pipeline?.name }}</dd>
+          <dt class="w-48 shrink-0 text-black">Pipeline</dt>
+          <dd class="text-muted min-w-0 flex-1 break-words text-left">{{ pipeline?.name }}</dd>
         </div>
         <div class="text-md flex border-b px-4 py-4">
-          <dt class="w-48 text-black">Laboratory</dt>
-          <dd class="text-muted text-left">{{ labName }}</dd>
+          <dt class="w-48 shrink-0 text-black">Laboratory</dt>
+          <dd class="text-muted min-w-0 flex-1 break-words text-left">{{ labName }}</dd>
         </div>
         <div class="text-md flex border-b px-4 py-4">
-          <dt class="w-48 text-black">Run Name</dt>
-          <dd class="text-muted text-left">{{ wipSeqeraRun?.runName }}</dd>
+          <dt class="w-48 shrink-0 text-black">Run Name</dt>
+          <dd class="text-muted min-w-0 flex-1 break-words text-left">{{ wipSeqeraRun?.runName }}</dd>
         </div>
         <div v-if="wipSeqeraRun?.description?.trim()" class="text-md flex border-b px-4 py-4">
-          <dt class="w-48 text-black">Description</dt>
-          <dd class="text-muted whitespace-pre-wrap break-words text-left">{{ wipSeqeraRun.description }}</dd>
+          <dt class="w-48 shrink-0 text-black">Description</dt>
+          <dd class="text-muted min-w-0 flex-1 whitespace-pre-wrap break-words text-left">
+            {{ wipSeqeraRun.description }}
+          </dd>
         </div>
         <EGRunCostRow :estimate="costEstimate" :loading="costEstimateLoading" class="border-b" />
       </dl>

--- a/packages/front-end/src/app/components/EGRunWorkflowFormReview.vue
+++ b/packages/front-end/src/app/components/EGRunWorkflowFormReview.vue
@@ -148,24 +148,28 @@
     <section class="stroke-light flex flex-col bg-white">
       <dl>
         <div class="text-md flex border-b px-4 py-4">
-          <dt class="w-48 text-black">Workflow</dt>
-          <dd class="text-muted text-left">{{ props.workflowName }}</dd>
+          <dt class="w-48 shrink-0 text-black">Workflow</dt>
+          <dd class="text-muted min-w-0 flex-1 break-words text-left">{{ props.workflowName }}</dd>
         </div>
         <div class="text-md flex border-b px-4 py-4">
-          <dt class="w-48 text-black">Workflow version</dt>
-          <dd class="text-muted text-left">{{ props.workflowVersionName || 'Default version' }}</dd>
+          <dt class="w-48 shrink-0 text-black">Workflow version</dt>
+          <dd class="text-muted min-w-0 flex-1 break-words text-left">
+            {{ props.workflowVersionName || 'Default version' }}
+          </dd>
         </div>
         <div class="text-md flex border-b px-4 py-4">
-          <dt class="w-48 text-black">Laboratory</dt>
-          <dd class="text-muted text-left">{{ labName }}</dd>
+          <dt class="w-48 shrink-0 text-black">Laboratory</dt>
+          <dd class="text-muted min-w-0 flex-1 break-words text-left">{{ labName }}</dd>
         </div>
         <div class="text-md flex border-b px-4 py-4">
-          <dt class="w-48 text-black">Run Name</dt>
-          <dd class="text-muted text-left">{{ props.runName }}</dd>
+          <dt class="w-48 shrink-0 text-black">Run Name</dt>
+          <dd class="text-muted min-w-0 flex-1 break-words text-left">{{ props.runName }}</dd>
         </div>
         <div v-if="wipOmicsRun?.description?.trim()" class="text-md flex border-b px-4 py-4">
-          <dt class="w-48 text-black">Description</dt>
-          <dd class="text-muted whitespace-pre-wrap break-words text-left">{{ wipOmicsRun.description }}</dd>
+          <dt class="w-48 shrink-0 text-black">Description</dt>
+          <dd class="text-muted min-w-0 flex-1 whitespace-pre-wrap break-words text-left">
+            {{ wipOmicsRun.description }}
+          </dd>
         </div>
         <EGRunCostRow :estimate="costEstimate" :loading="costEstimateLoading" class="border-b" />
       </dl>

--- a/packages/front-end/src/app/pages/labs/[labId]/run/[labRunId].vue
+++ b/packages/front-end/src/app/pages/labs/[labId]/run/[labRunId].vue
@@ -308,8 +308,8 @@
   }
 
   const rowStyle = 'flex border-b p-6 text-sm';
-  const rowLabelStyle = 'w-[200px] font-medium text-black';
-  const rowContentStyle = 'text-muted text-left';
+  const rowLabelStyle = 'w-[200px] shrink-0 font-medium text-black';
+  const rowContentStyle = 'min-w-0 flex-1 break-words text-muted text-left';
 
   const showSeqeraProgressCard = computed<boolean>(() =>
     showSeqeraTaskProgressCard(labRun.value, {
@@ -476,7 +476,7 @@
 
             <div v-if="labRun.Description" :class="rowStyle">
               <dt :class="rowLabelStyle">Description</dt>
-              <dd :class="rowContentStyle">{{ labRun.Description }}</dd>
+              <dd :class="[rowContentStyle, 'whitespace-pre-wrap']">{{ labRun.Description }}</dd>
             </div>
 
             <div :class="rowStyle">


### PR DESCRIPTION
## fix: keep long run descriptions aligned in details and review

## Type of Change*
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
- Long run descriptions (up to 500 characters, including strings with no spaces) were shrinking the label column and breaking value alignment on Run Details and the Review and launch step.
- Lock labels at a fixed width and wrap values in the remaining column so Description stays aligned with the other fields.

## Testing*
- Launch wizard Step 4: enter a 500-character description with no spaces and confirm the value column still lines up with Workflow / Run Name.
- After launch, open Run Details and confirm the same alignment for Description.
- Confirm a short/normal description is unchanged.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [x] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.