### PR TITLE
fix(lab-settings): dedupe VPC networking copy and fix notification spacing

### DIFF
--- a/packages/front-end/src/app/components/EGCollapsibleSection.vue
+++ b/packages/front-end/src/app/components/EGCollapsibleSection.vue
@@ -10,11 +10,14 @@
       headingId: string;
       title: string;
       description?: string;
+      /** Extra detail shown in a hover tooltip next to the description, e.g. why a feature exists. */
+      descriptionTooltip?: string;
       badges?: Badge[];
       defaultOpen?: boolean;
     }>(),
     {
       description: '',
+      descriptionTooltip: '',
       badges: () => [],
       defaultOpen: false,
     },
@@ -29,34 +32,51 @@
 
 <template>
   <EGCard :padding="0">
-    <button
-      type="button"
-      class="hover:bg-primary-muted flex w-full items-center justify-between gap-4 px-6 py-4 text-left"
-      :aria-expanded="isOpen"
-      :aria-controls="`${headingId}-content`"
-      @click="isOpen = !isOpen"
-    >
-      <span>
+    <div>
+      <button
+        type="button"
+        class="hover:bg-primary-muted flex w-full items-center justify-between gap-4 px-6 pt-4 text-left"
+        :class="description ? 'pb-1' : 'pb-4'"
+        :aria-expanded="isOpen"
+        :aria-controls="`${headingId}-content`"
+        @click="isOpen = !isOpen"
+      >
         <span :id="headingId" class="block text-sm font-medium text-black">{{ title }}</span>
-        <span v-if="description" class="text-muted mt-1 block text-xs">{{ description }}</span>
-      </span>
-      <span class="flex shrink-0 items-center gap-2">
-        <UBadge
-          v-for="badge in badges"
-          :key="badge.label"
-          :ui="{ rounded: 'rounded-xl', base: 'uppercase' }"
-          :class="badgeClass(badge.tone)"
+        <span class="flex shrink-0 items-center gap-2">
+          <UBadge
+            v-for="badge in badges"
+            :key="badge.label"
+            :ui="{ rounded: 'rounded-xl', base: 'uppercase' }"
+            :class="badgeClass(badge.tone)"
+          >
+            {{ badge.label }}
+          </UBadge>
+          <UIcon
+            name="i-heroicons-chevron-down"
+            class="h-5 w-5 shrink-0 transition-transform"
+            :class="{ 'rotate-180': isOpen }"
+            aria-hidden="true"
+          />
+        </span>
+      </button>
+      <div v-if="description" class="flex items-center gap-1.5 px-6 pb-4">
+        <p class="text-muted text-xs">{{ description }}</p>
+        <UTooltip
+          v-if="descriptionTooltip"
+          :delay-duration="0"
+          :ui="{ base: 'h-auto w-auto max-w-sm whitespace-normal text-left' }"
         >
-          {{ badge.label }}
-        </UBadge>
-        <UIcon
-          name="i-heroicons-chevron-down"
-          class="h-5 w-5 shrink-0 transition-transform"
-          :class="{ 'rotate-180': isOpen }"
-          aria-hidden="true"
-        />
-      </span>
-    </button>
+          <template #text>
+            <p>{{ descriptionTooltip }}</p>
+          </template>
+          <UIcon
+            name="i-heroicons-information-circle"
+            class="text-muted h-4 w-4 shrink-0"
+            :aria-label="`${title} guidance`"
+          />
+        </UTooltip>
+      </div>
+    </div>
     <div
       v-if="isOpen"
       :id="`${headingId}-content`"

--- a/packages/front-end/src/app/components/EGFormLabDetails.vue
+++ b/packages/front-end/src/app/components/EGFormLabDetails.vue
@@ -1393,7 +1393,6 @@
         :badges="[healthOmicsVpcNetworkingBadge]"
       >
         <div class="mb-3 flex items-center gap-1.5">
-          <p class="text-muted text-xs">Routes this lab's HealthOmics runs through a saved VPC configuration.</p>
           <UTooltip :delay-duration="0" :ui="{ base: 'h-auto w-auto max-w-sm whitespace-normal text-left' }">
             <template #text>
               <p>
@@ -1493,27 +1492,33 @@
         <USkeleton v-if="isLoadingNotificationPrefs" class="mt-4 h-24 w-full" aria-hidden="true" />
         <template v-else>
           <!-- Per-user preferences: staged locally like every other field, saved via Save Changes -->
-          <div class="mt-4 flex items-center justify-between">
-            <span :id="notifyOwnRunsToggleLabelId" class="text-sm text-black">Email me about my own runs</span>
-            <UToggle
-              class="ml-2"
-              v-model="notifyOnOwnRunsEnabled"
-              :disabled="!isEditing || isSubmittingFormData"
-              :aria-labelledby="notifyOwnRunsToggleLabelId"
-            />
-          </div>
+          <EGFormGroup name="NotifyOnOwnRuns" eager-validation>
+            <div class="flex items-center justify-between">
+              <span :id="notifyOwnRunsToggleLabelId" class="text-sm text-black">Email me about my own runs</span>
+              <UToggle
+                class="ml-2"
+                v-model="notifyOnOwnRunsEnabled"
+                :disabled="!isEditing || isSubmittingFormData"
+                :aria-labelledby="notifyOwnRunsToggleLabelId"
+              />
+            </div>
+          </EGFormGroup>
 
-          <div class="mt-3 flex items-center justify-between">
-            <span :id="notifyLabRunsToggleLabelId" class="text-sm text-black">Email me about all runs in this lab</span>
-            <UToggle
-              class="ml-2"
-              v-model="notifyOnLabRunsEnabled"
-              :disabled="!isEditing || isSubmittingFormData"
-              :aria-labelledby="notifyLabRunsToggleLabelId"
-            />
-          </div>
+          <EGFormGroup name="NotifyOnLabRuns" eager-validation>
+            <div class="flex items-center justify-between">
+              <span :id="notifyLabRunsToggleLabelId" class="text-sm text-black">
+                Email me about all runs in this lab
+              </span>
+              <UToggle
+                class="ml-2"
+                v-model="notifyOnLabRunsEnabled"
+                :disabled="!isEditing || isSubmittingFormData"
+                :aria-labelledby="notifyLabRunsToggleLabelId"
+              />
+            </div>
+          </EGFormGroup>
 
-          <div v-if="notifyOnLabRunsEnabled" class="mt-3">
+          <EGFormGroup v-if="notifyOnLabRunsEnabled" name="NotifyOnLabRunsAdditionalEmailsInput" eager-validation>
             <label :for="notifyLabRunsAdditionalEmailsInputId" class="mb-1 block text-sm text-black">
               Also CC these emails on every lab run
             </label>
@@ -1529,9 +1534,9 @@
             <p v-else class="text-muted mt-1 text-xs">
               Comma-separated, up to 10. Sent whenever your own "all runs in this lab" notification fires.
             </p>
-          </div>
+          </EGFormGroup>
 
-          <div v-if="showNotificationEventFilter" class="mt-4">
+          <EGFormGroup v-if="showNotificationEventFilter" name="NotificationEventFilter" eager-validation>
             <p class="mb-2 text-sm text-black">Notify me when a run</p>
             <div class="flex flex-col gap-2">
               <UCheckbox
@@ -1547,7 +1552,7 @@
                 @update:model-value="onToggleNotifyFailures"
               />
             </div>
-          </div>
+          </EGFormGroup>
         </template>
       </EGCollapsibleSection>
     </div>

--- a/packages/front-end/src/app/components/EGFormLabDetails.vue
+++ b/packages/front-end/src/app/components/EGFormLabDetails.vue
@@ -1390,24 +1390,9 @@
         heading-id="lab-settings-healthomics-vpc-networking-heading"
         title="HealthOmics VPC Networking"
         description="Route this lab's HealthOmics runs through a custom VPC configuration."
+        description-tooltip="Lets runs reach resources outside the default restricted network — for example internet reference datasets, license servers, or private VPC and on-prem data."
         :badges="[healthOmicsVpcNetworkingBadge]"
       >
-        <div class="mb-3 flex items-center gap-1.5">
-          <UTooltip :delay-duration="0" :ui="{ base: 'h-auto w-auto max-w-sm whitespace-normal text-left' }">
-            <template #text>
-              <p>
-                Lets runs reach resources outside the default restricted network — for example internet reference
-                datasets, license servers, or private VPC and on-prem data.
-              </p>
-            </template>
-            <UIcon
-              name="i-heroicons-information-circle"
-              class="text-muted h-4 w-4 shrink-0"
-              aria-label="VPC networking guidance"
-            />
-          </UTooltip>
-        </div>
-
         <EGFormGroup label="Networking mode" name="AwsHealthOmicsNetworkingMode" eager-validation>
           <div class="mb-2 flex items-center gap-1.5">
             <p class="text-muted text-xs">Only available when HealthOmics is enabled.</p>


### PR DESCRIPTION
## Summary
Clean up redundant copy and uneven vertical rhythm in Lab Settings sections called out by design review.

- **HealthOmics VPC Networking**: removed the duplicated near-identical descriptions ("Route…custom VPC…" / "Routes…saved VPC…"). The section header now shows a single clear description line, with the info icon moved inline next to it (via a new optional `description-tooltip` prop on `EGCollapsibleSection`) instead of sitting orphaned in the body.
- **Run Notifications**: the four per-user preference rows (own-runs toggle, lab-runs toggle, additional-emails input, event-filter checkboxes) were raw `<div>`s with ad hoc `mt-3`/`mt-4` classes, causing uneven gaps. They're now wrapped in `EGFormGroup`, matching the `mb-6` rhythm used by every other field on this form.

## Acceptance criteria
- [x] HealthOmics VPC Networking no longer shows duplicated descriptions; single clear line of copy.
- [x] Run Notifications section spacing is consistent between header, toggles, and hints.
- [x] Section expand/collapse and toggle behavior unchanged.

## Files touched
- `packages/front-end/src/app/components/EGFormLabDetails.vue`
- `packages/front-end/src/app/components/EGCollapsibleSection.vue` (added optional `descriptionTooltip` prop; only consumer is `EGFormLabDetails.vue`, verified via repo-wide search)

## Testing
Manual — verified visually that the VPC Networking card shows one description with the info icon inline, and Run Notifications rows have even spacing. Toggle/checkbox bindings and expand/collapse behavior untouched. `pnpm lint`/`pnpm test` pass for back-end and shared-lib (front-end has no lint/test coverage for `.vue` files in this package).

🤖 Generated with [Claude Code](https://claude.com/claude-code)