### PR TITLE
fix: fit dashboard spend, escape-dismiss dialogs, and basic shell responsiveness

### DIFF
--- a/packages/front-end/src/app/components/EGDashboard.vue
+++ b/packages/front-end/src/app/components/EGDashboard.vue
@@ -612,8 +612,8 @@
 <template>
   <div class="dashboard" :aria-busy="uiStore.isRequestPending('loadDashboardData')">
     <!-- Header: Title + Search -->
-    <div class="mb-2 flex items-center justify-between">
-      <div>
+    <div class="mb-2 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+      <div class="min-w-0">
         <button
           type="button"
           class="text-primary focus-visible:outline-primary-500 mb-2 flex items-center gap-1 border-0 bg-transparent p-0 text-sm font-medium focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
@@ -624,7 +624,7 @@
         </button>
         <EGText tag="h1" size="md" class="mb-0">Laboratory of {{ labName }}</EGText>
       </div>
-      <div class="relative w-[320px]">
+      <div class="relative w-full max-w-[320px] sm:shrink-0">
         <label :for="searchInputId" class="sr-only">Search runs, workflows, and results</label>
         <UInput
           :id="searchInputId"
@@ -657,7 +657,7 @@
 
         <div
           v-if="showDropdown"
-          class="absolute right-0 top-full z-50 mt-1 w-[420px] overflow-hidden rounded-xl border border-neutral-100 bg-white shadow-lg"
+          class="absolute left-0 right-0 top-full z-50 mt-1 w-full overflow-hidden rounded-xl border border-neutral-100 bg-white shadow-lg sm:left-auto sm:w-[420px]"
           role="presentation"
         >
           <div v-if="searchResults.length === 0" class="text-muted px-4 py-6 text-center text-sm" role="status">
@@ -844,22 +844,29 @@
         </div>
       </div>
 
-      <dl class="mt-4 grid grid-cols-2 gap-4 lg:grid-cols-5">
+      <dl class="mt-4 grid grid-cols-2 gap-3 sm:gap-4 xl:grid-cols-5">
         <div
           v-for="stat in overviewStats"
           :key="stat.key"
-          class="flex items-center gap-4 rounded-2xl border border-neutral-100 bg-white p-6"
+          class="flex min-w-0 items-center gap-3 rounded-2xl border border-neutral-100 bg-white p-4 sm:gap-4 sm:p-6"
         >
           <div
-            class="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl"
+            class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl sm:h-12 sm:w-12"
             :class="stat.bgColor"
             aria-hidden="true"
           >
-            <UIcon :name="stat.icon" class="h-6 w-6" :class="stat.iconColor" />
+            <UIcon :name="stat.icon" class="h-5 w-5 sm:h-6 sm:w-6" :class="stat.iconColor" />
           </div>
-          <div>
-            <dt class="text-muted text-sm">{{ stat.label }}</dt>
-            <dd class="text-heading m-0 font-serif text-3xl font-semibold">{{ stat.value }}</dd>
+          <div class="min-w-0">
+            <dt class="text-muted leading-snug" :class="stat.key === 'run-spend' ? 'text-xs' : 'text-xs sm:text-sm'">
+              {{ stat.label }}
+            </dt>
+            <dd
+              class="text-heading m-0 break-words font-serif font-semibold"
+              :class="stat.key === 'run-spend' ? 'text-xl sm:text-2xl' : 'text-2xl sm:text-3xl'"
+            >
+              {{ stat.value }}
+            </dd>
           </div>
         </div>
       </dl>

--- a/packages/front-end/src/app/components/EGDialog.vue
+++ b/packages/front-end/src/app/components/EGDialog.vue
@@ -17,12 +17,25 @@
 
   const titleId = useId();
 
+  const isLocked = computed(() => Boolean(props.buttonsDisabled || props.loading));
+
   function handleCancel() {
+    if (isLocked.value) {
+      return;
+    }
     emit('update:modelValue', false);
   }
 
   function handleClick() {
     emit('action-triggered');
+  }
+
+  function onModelValueUpdate(value: boolean) {
+    // Allow Escape / overlay dismiss when the dialog is not mid-action; keep locked while loading.
+    if (value === false && isLocked.value) {
+      return;
+    }
+    emit('update:modelValue', value);
   }
 </script>
 
@@ -37,8 +50,8 @@
       width: 'sm:max-w-2xl',
     }"
     :modelValue="modelValue"
-    @update:modelValue="(value) => emit('update:modelValue', value)"
-    prevent-close
+    @update:modelValue="onModelValueUpdate"
+    :prevent-close="isLocked"
     role="dialog"
     aria-modal="true"
     :aria-labelledby="titleId"
@@ -64,7 +77,7 @@
                 color="black"
                 variant="ghost"
                 :ui="{ rounded: 'rounded-full' }"
-                :disabled="buttonsDisabled || loading"
+                :disabled="isLocked"
                 aria-label="Close dialog"
               />
             </div>
@@ -72,14 +85,14 @@
           <div v-if="secondaryMessage">
             <EGText tag="p" class="mb-6 whitespace-pre-line break-words">{{ secondaryMessage }}</EGText>
           </div>
-          <div class="flex justify-end gap-4">
+          <div class="flex flex-wrap justify-end gap-4">
             <div v-if="cancelLabel">
               <EGButton
                 @click="handleCancel"
                 :label="cancelLabel"
                 :variant="ButtonVariantEnum.enum.secondary"
                 :size="ButtonSizeEnum.enum.sm"
-                :disabled="buttonsDisabled || loading"
+                :disabled="isLocked"
               />
             </div>
             <EGButton
@@ -87,7 +100,7 @@
               :label="actionLabel"
               :size="ButtonSizeEnum.enum.sm"
               :variant="actionVariant"
-              :disabled="buttonsDisabled || loading"
+              :disabled="isLocked"
               :loading="loading"
               autofocus
             />

--- a/packages/front-end/src/app/components/EGHeader.vue
+++ b/packages/front-end/src/app/components/EGHeader.vue
@@ -190,19 +190,22 @@
 </script>
 
 <template>
-  <header class="flex flex-row items-center px-8">
-    <div class="header-container" :class="{ 'flex w-full flex-row items-center justify-between': props.isAuthed }">
+  <header class="flex flex-row items-center px-4 md:px-8">
+    <div
+      class="header-container"
+      :class="{ 'flex w-full min-w-0 flex-row items-center justify-between gap-3': props.isAuthed }"
+    >
       <template v-if="props.isAuthed">
         <NuxtLink
           :to="homePath"
-          class="focus-visible:outline-primary-500 mr-2 rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
+          class="focus-visible:outline-primary-500 mr-2 shrink-0 rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
           aria-label="Easy Genomics home"
         >
-          <img class="w-[140px]" src="@/assets/images/easy-genomics-logo.svg" alt="EasyGenomics logo" />
+          <img class="w-[120px] md:w-[140px]" src="@/assets/images/easy-genomics-logo.svg" alt="EasyGenomics logo" />
         </NuxtLink>
 
-        <div class="flex min-w-0 items-center gap-4">
-          <nav aria-label="Primary" class="flex min-w-0 items-center gap-4">
+        <div class="flex min-w-0 items-center gap-2 md:gap-4">
+          <nav aria-label="Primary" class="flex min-w-0 items-center gap-2 md:gap-4">
             <ULink
               v-if="!userStore.isSuperuser"
               :to="labsPath"
@@ -211,7 +214,7 @@
               inactive-class="text-body"
               active-class="text-primary-dark bg-primary-muted"
               :class="isSubpath(labsPath) ? 'text-primary-dark bg-primary-muted' : ''"
-              class="ULink text-body focus-visible:outline-primary-500 flex h-[30px] max-w-[min(100%,18rem)] items-center justify-center rounded-xl px-4 py-1 font-serif text-sm tracking-normal focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
+              class="ULink text-body focus-visible:outline-primary-500 flex h-[30px] max-w-[min(100%,12rem)] items-center justify-center rounded-xl px-3 py-1 font-serif text-sm tracking-normal focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 md:max-w-[min(100%,18rem)] md:px-4"
             >
               <span class="truncate">{{ labsNavLabel }}</span>
             </ULink>
@@ -222,7 +225,7 @@
               inactive-class="text-body"
               active-class="text-primary-dark bg-primary-muted"
               :class="isSubpath(orgsPath) ? 'text-primary-dark bg-primary-muted' : ''"
-              class="ULink text-body focus-visible:outline-primary-500 flex h-[30px] items-center justify-center whitespace-nowrap rounded-xl px-4 py-1 font-serif text-sm tracking-normal focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
+              class="ULink text-body focus-visible:outline-primary-500 flex h-[30px] items-center justify-center whitespace-nowrap rounded-xl px-3 py-1 font-serif text-sm tracking-normal focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 md:px-4"
             >
               Organizations
             </ULink>

--- a/packages/front-end/src/app/components/EGLabView.vue
+++ b/packages/front-end/src/app/components/EGLabView.vue
@@ -981,13 +981,13 @@
   <div v-if="activeTabKey === 'runs'" role="tabpanel" id="panel-runs" aria-labelledby="tab-runs" tabindex="0">
     <h2 class="sr-only">Pipeline runs</h2>
     <div class="mb-6">
-      <div class="flex flex-row items-center gap-4">
+      <div class="flex flex-col gap-4 sm:flex-row sm:items-center">
         <EGSearchInput
           @input-event="updateRunsSearchQuery"
           label="Search runs"
           placeholder="Search runs"
           :disabled="useUiStore().anyRequestPending(['loadLabData', 'loadLabRuns'])"
-          class="w-[408px]"
+          class="w-full max-w-[408px]"
         />
         <div class="flex items-center gap-2">
           <UToggle
@@ -1228,7 +1228,7 @@
         label="Search users"
         placeholder="Search user"
         :disabled="useUiStore().anyRequestPending(['loadLabData', 'getLabUsers', 'addUserToLab'])"
-        class="my-6 w-[408px]"
+        class="my-6 w-full max-w-[408px]"
       />
       <p class="sr-only" aria-live="polite" aria-atomic="true">{{ usersSearchStatusMessage }}</p>
 

--- a/packages/front-end/src/app/components/EGSidebarNav.vue
+++ b/packages/front-end/src/app/components/EGSidebarNav.vue
@@ -146,7 +146,11 @@
       </span>
     </div>
 
-    <div role="tablist" aria-orientation="vertical" class="sidebar-nav__tabs flex min-h-0 flex-1 flex-col">
+    <div
+      role="tablist"
+      aria-orientation="vertical"
+      class="sidebar-nav__tabs flex min-h-0 flex-1 flex-col overflow-y-auto"
+    >
       <template v-for="(item, index) in items" :key="item.key">
         <div
           v-if="item.dividerBefore"

--- a/packages/front-end/src/app/layouts/default.vue
+++ b/packages/front-end/src/app/layouts/default.vue
@@ -7,6 +7,20 @@
   const route = useRoute();
   const isFullWidthContent = computed(() => Boolean(route.meta.fullWidthContent));
 
+  // Basic shell responsiveness: collapse the sidebar on narrower viewports so content isn't crushed.
+  const NARROW_SHELL_MQ = '(max-width: 1024px)';
+  let narrowShellMql: MediaQueryList | null = null;
+
+  function syncSidebarToViewport(matchesNarrow: boolean) {
+    if (matchesNarrow) {
+      uiStore.setSidebarCollapsed(true);
+    }
+  }
+
+  function onNarrowShellChange(event: MediaQueryListEvent) {
+    syncSidebarToViewport(event.matches);
+  }
+
   /**
    * @description Initialize the app for authed users; set the current user's organization with
    * future scope to add user display details (name, email, etc.)
@@ -14,6 +28,20 @@
   onBeforeMount(async () => {
     await setCurrentUserDataFromToken();
     hasInit.value = true;
+  });
+
+  onMounted(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    narrowShellMql = window.matchMedia(NARROW_SHELL_MQ);
+    syncSidebarToViewport(narrowShellMql.matches);
+    narrowShellMql.addEventListener('change', onNarrowShellChange);
+  });
+
+  onBeforeUnmount(() => {
+    narrowShellMql?.removeEventListener('change', onNarrowShellChange);
+    narrowShellMql = null;
   });
 
   watch(routeKey, () => {
@@ -63,6 +91,15 @@
         width: calc(100% - var(--sidebar-width-collapsed) - 2 * var(--sidebar-content-gap));
         margin-left: calc(var(--sidebar-width-collapsed) + var(--sidebar-content-gap));
       }
+    }
+  }
+
+  @media (max-width: 1024px) {
+    main.has-sidebar:not(.has-sidebar--collapsed) {
+      // Prefer the collapsed content gutter when the viewport is narrow even if the
+      // sidebar is temporarily expanded, so the main column does not overflow.
+      width: calc(100% - var(--sidebar-width-collapsed) - 2 * var(--sidebar-content-gap));
+      margin-left: calc(var(--sidebar-width-collapsed) + var(--sidebar-content-gap));
     }
   }
 </style>


### PR DESCRIPTION
## fix: fit dashboard spend, escape-dismiss dialogs, and basic shell responsiveness

## Type of Change*
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
- Shrink Estimated run spend / metric card typography and layout so long values fit without overflow.
- Allow Escape (and overlay) to cancel dismissible `EGDialog` prompts; keep dialogs locked while loading; leave forced offline modal non-dismissible.
- Add basic responsiveness for the shell and touched content: auto-collapse sidebar ≤1024px, fluid search widths, and tighter header spacing on narrower viewports.

## Testing*
- Dashboard Lab metrics: “Estimated run spend” / long `≈ US$…` values fit in the card without overflow or clipping.
- Open a confirm dialog (e.g. remove user) → Escape closes it; Cancel/X still work; while an action is loading, Escape does not dismiss.
- Offline / forced modal (if available) still cannot be dismissed with Escape.
- At ≤1024px width, sidebar auto-collapses and main content does not overflow horizontally.
- Dashboard and lab runs/users search inputs shrink with the viewport instead of forcing fixed widths.
- Header logo / Labs / Organizations remain usable on a narrower viewport.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [x] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.