### PR TITLE
fix: Remove Edit button from Lab Settings — make fields always editable

### DIFF
--- a/packages/front-end/src/app/components/EGFormLabDetails.vue
+++ b/packages/front-end/src/app/components/EGFormLabDetails.vue
@@ -40,7 +40,7 @@
       formMode?: LabDetailsFormMode;
     }>(),
     {
-      formMode: LabDetailsFormModeEnum.enum.ReadOnly,
+      formMode: LabDetailsFormModeEnum.enum.Edit,
     },
   );
 
@@ -465,8 +465,6 @@
     }
   }
 
-  const hasEditPermission = computed<boolean>(() => useUserStore().canEditLabDetails());
-
   /**
    * Retrieves the lab details from the server and sets the form state.
    */
@@ -516,8 +514,8 @@
   /**
    * Cancel current edit operation.
    *
-   * It resets the state value to the original unedited lab details,  turns off the editing mode for the Nextflow Tower
-   * access token, disables the submit button, and switches the form mode to read-only.
+   * It resets the state value to the original unedited lab details, turns off the editing mode for the Nextflow Tower
+   * access token, and disables the submit button. Fields remain editable — there is no read-only mode to revert to.
    *
    * @return {void}
    */
@@ -532,7 +530,6 @@
     canSubmit.value = false;
     retentionPreviewCacheMonths.value = null;
     retentionPreviewCounts.value = null;
-    switchToFormMode(LabDetailsFormModeEnum.enum.ReadOnly);
   }
 
   const isSubmittingFormData = computed(
@@ -671,7 +668,6 @@
       emit('updated');
       isEditingNextFlowTowerAccessToken.value = false;
       isEditingGitHubAccessToken.value = false;
-      switchToFormMode(LabDetailsFormModeEnum.enum.ReadOnly);
       retentionPreviewCacheMonths.value = null;
       retentionPreviewCounts.value = null;
       await getLabDetails();
@@ -745,7 +741,6 @@
 
     isEditingNextFlowTowerAccessToken.value = false;
     isEditingGitHubAccessToken.value = false;
-    switchToFormMode(LabDetailsFormModeEnum.enum.ReadOnly);
     await getLabDetails();
 
     useToastStore().success(`${lab.Name} successfully updated`);
@@ -1569,17 +1564,6 @@
         label="Cancel"
         name="cancel"
         @click="$router.push(useUiStore().previousPageRoute)"
-      />
-    </div>
-
-    <!-- Form Buttons: Read Mode -->
-    <div v-if="formMode === LabDetailsFormModeEnum.enum.ReadOnly" class="mt-6 flex space-x-2">
-      <EGButton
-        :size="ButtonSizeEnum.enum.sm"
-        u-button-type="button"
-        label="Edit"
-        :disabled="useUserStore().isSuperuser || !hasEditPermission"
-        @click="switchToFormMode(LabDetailsFormModeEnum.enum.Edit)"
       />
     </div>
 

--- a/packages/front-end/src/app/components/EGLabView.vue
+++ b/packages/front-end/src/app/components/EGLabView.vue
@@ -166,7 +166,7 @@
     }
     items.push(dataCollectionsTab);
     items.push({ ...usersTab, dividerBefore: items.length > 0 });
-    items.push(detailsTab);
+    if (!userStore.isSuperuser && userStore.canEditLabDetails()) items.push(detailsTab);
 
     return items;
   });

--- a/packages/front-end/tests/e2e/lab-manager/Labs_Lab_Manager.spec.e2e.ts
+++ b/packages/front-end/tests/e2e/lab-manager/Labs_Lab_Manager.spec.e2e.ts
@@ -56,7 +56,7 @@ test('03 - Hide Organization link', async ({ page, baseURL }) => {
   await expect(page.getByRole('link', { name: 'Organizations' })).toBeHidden();
 });
 
-test('04 - Disable Editing Lab Details', async ({ page, baseURL }) => {
+test('04 - Hide Lab Settings tab', async ({ page, baseURL }) => {
   await page.goto(`${baseURL}/labs`);
   await page.waitForLoadState('networkidle');
 
@@ -70,10 +70,9 @@ test('04 - Disable Editing Lab Details', async ({ page, baseURL }) => {
   if (hasTestLab == true) {
     await page.getByRole('row', { name: labName }).locator('button').click();
     await page.getByRole('menuitem', { name: 'View / Edit' }).click();
-    await page.getByRole('tab', { name: 'Settings' }).click();
 
-    // check if Edit is disabled
-    await expect(page.getByRole('button', { name: 'Edit' })).toBeDisabled();
+    // Lab managers cannot edit lab details, so the Settings tab is not shown
+    await expect(page.getByRole('tab', { name: 'Settings' })).toBeHidden();
   } else {
     console.log('Cannot find ' + labName);
   }
@@ -91,10 +90,9 @@ test('04 - Disable Editing Lab Details', async ({ page, baseURL }) => {
   if (hasUpdatedTestLab == true) {
     await page.getByRole('row', { name: labNameUpdated }).locator('button').click();
     await page.getByRole('menuitem', { name: 'View / Edit' }).click();
-    await page.getByRole('tab', { name: 'Settings' }).click();
 
-    // check if Edit is disabled
-    await expect(page.getByRole('button', { name: 'Edit' })).toBeDisabled();
+    // Lab managers cannot edit lab details, so the Settings tab is not shown
+    await expect(page.getByRole('tab', { name: 'Settings' })).toBeHidden();
   } else {
     console.log('Cannot find ' + labNameUpdated);
   }

--- a/packages/front-end/tests/e2e/lab-technician/Labs_Lab_Technician.spec.e2e.ts
+++ b/packages/front-end/tests/e2e/lab-technician/Labs_Lab_Technician.spec.e2e.ts
@@ -40,7 +40,7 @@ test('03 - Hide Organization link', async ({ page, baseURL }) => {
   await expect(page.getByRole('link', { name: 'Organizations' })).toBeHidden();
 });
 
-test('04 - Disable Editing Lab Details', async ({ page, baseURL }) => {
+test('04 - Hide Lab Settings tab', async ({ page, baseURL }) => {
   await page.goto(`${baseURL}/labs`);
   await page.waitForLoadState('networkidle');
 
@@ -54,10 +54,9 @@ test('04 - Disable Editing Lab Details', async ({ page, baseURL }) => {
   if (hasTestLab == true) {
     await page.getByRole('row', { name: labName }).locator('button').click();
     await page.getByRole('menuitem', { name: 'View / Edit' }).click();
-    await page.getByRole('tab', { name: 'Settings' }).click();
 
-    // check if Edit is disabled
-    await expect(page.getByRole('button', { name: 'Edit' })).toBeDisabled();
+    // Lab technicians cannot edit lab details, so the Settings tab is not shown
+    await expect(page.getByRole('tab', { name: 'Settings' })).toBeHidden();
   }
 
   await page.goto(`${baseURL}/labs`);
@@ -73,9 +72,8 @@ test('04 - Disable Editing Lab Details', async ({ page, baseURL }) => {
   if (hasUpdatedTestLab == true) {
     await page.getByRole('row', { name: labNameUpdated }).locator('button').click();
     await page.getByRole('menuitem', { name: 'View / Edit' }).click();
-    await page.getByRole('tab', { name: 'Settings' }).click();
 
-    // check if Edit is disabled
-    await expect(page.getByRole('button', { name: 'Edit' })).toBeDisabled();
+    // Lab technicians cannot edit lab details, so the Settings tab is not shown
+    await expect(page.getByRole('tab', { name: 'Settings' })).toBeHidden();
   }
 });

--- a/packages/front-end/tests/e2e/org-admin/Labs_Org_Admin.spec.e2e.ts
+++ b/packages/front-end/tests/e2e/org-admin/Labs_Org_Admin.spec.e2e.ts
@@ -205,7 +205,6 @@ test('04 - Update a Laboratory Successfully', async ({ page, baseURL }) => {
     await page.getByRole('menuitem', { name: 'View / Edit' }).click();
     await page.waitForTimeout(5 * 1000); // this waits for s3 bucket info to load
     await page.getByRole('tab', { name: 'Settings' }).click();
-    await page.getByRole('button', { name: 'Edit' }).click();
 
     await page.getByPlaceholder('Enter lab name (required and').click();
     await page.getByPlaceholder('Enter lab name (required and').fill(labNameUpdated);
@@ -377,7 +376,6 @@ test('08 - Enable HealthOmics Integration Successfully', async ({ page, baseURL 
     await page.getByRole('menuitem', { name: 'View / Edit' }).click();
     await page.waitForTimeout(5 * 1000); // this waits for s3 bucket info to load
     await page.getByRole('tab', { name: 'Settings' }).click();
-    await page.getByRole('button', { name: 'Edit' }).click();
 
     let omicsEnabled = true;
     try {


### PR DESCRIPTION
## Type of Change*
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [x] UI/UX improvement
- [ ] Hotfix
- [ ] Security patch

## Description
Lab Settings (`EGFormLabDetails.vue`, the "Settings" tab in `EGLabView.vue`) previously opened read-only and required clicking an Edit button before any field could be changed. This added an unnecessary extra step for a page that's only visited with intent to change something.

Changes:
- `EGFormLabDetails.vue`: default `formMode` changed from `ReadOnly` to `Edit`, so fields render as always-editable. Removed the Edit button and the `switchToFormMode(ReadOnly)` calls after Save/Cancel — the form simply stays in Edit mode. The Save Changes / Cancel button row (previously shown only in Edit mode) is now the permanent action row. Removed the now-unused `hasEditPermission` computed.
- `EGLabView.vue`: the "Settings" tab is now only added to the tab list when `!userStore.isSuperuser && userStore.canEditLabDetails()`. This replaces the previous behaviour of showing a *disabled* Edit button for superusers/non-org-admins with hiding the tab entirely for those users.
- Lab creation (`pages/labs/create.vue`, `Create` form mode) is unaffected — this only touches the existing-lab Settings flow.

Out of scope: the `labs.update` API contract, `useLabsStore`, masked-secret (NextFlow Tower / GitHub token) reveal UX, and autosave — Save remains an explicit action.

## Testing*
- `pnpm lint` and `pnpm test` in `packages/front-end` pass (12 suites / 106 tests).
- Updated E2E specs to match the new behavior:
  - `Labs_Org_Admin.spec.e2e.ts`: removed the Edit-button click before filling Settings fields (fields are now editable immediately after opening the tab).
  - `Labs_Lab_Manager.spec.e2e.ts` / `Labs_Lab_Technician.spec.e2e.ts`: replaced "Edit button is disabled" assertions with "Settings tab is hidden" assertions.
- Not yet verified: the updated E2E specs have not been run against a deployed `quality` environment (per repo convention, they require real infra). To verify: run `pnpm test-e2e:org-admin`, `pnpm test-e2e:lab-manager`, `pnpm test-e2e:lab-technician` against `quality`, and manually confirm Cancel still reverts unsaved edits with no separate edit-mode toggle.

## Impact
Front-end only, no schema/API/infra changes. Behaviour change: users without lab-edit permission (org non-admins) and superusers no longer see the Lab Settings tab at all — previously they saw it with a disabled Edit button (so they could view but not edit). This trades away read-only visibility for those users in exchange for removing the edit-mode toggle for everyone else.

## Additional Information
None.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [ ] All tests pass successfully and new tests added as necessary. *(existing E2E specs updated to match new behavior; no new test cases added since this removes a UI step rather than adding capability)*
- [ ] Documentation has been updated accordingly. *(N/A — no user-facing docs affected)*
- [x] Code adheres to the coding and style guidelines of the project.
- [ ] Code has been commented in particularly hard-to-understand areas. *(N/A — removals/simplifications, no new complex logic)*
