### PR TITLE
fix: show loading skeletons on first paint instead of flashing content

### DIFF
--- a/packages/front-end/src/app/components/EGCollapsibleSection.vue
+++ b/packages/front-end/src/app/components/EGCollapsibleSection.vue
@@ -32,10 +32,10 @@
 
 <template>
   <EGCard :padding="0">
-    <div>
+    <div class="isolate overflow-hidden" :class="isOpen || description ? 'rounded-t-2xl' : 'rounded-2xl'">
       <button
         type="button"
-        class="hover:bg-primary-muted flex w-full items-center justify-between gap-4 px-6 pt-4 text-left"
+        class="hover:bg-primary-muted flex w-full appearance-none items-center justify-between gap-4 border-0 bg-transparent px-6 pt-4 text-left transition-colors"
         :class="description ? 'pb-1' : 'pb-4'"
         :aria-expanded="isOpen"
         :aria-controls="`${headingId}-content`"
@@ -59,23 +59,23 @@
           />
         </span>
       </button>
-      <div v-if="description" class="flex items-center gap-1.5 px-6 pb-4">
-        <p class="text-muted text-xs">{{ description }}</p>
-        <UTooltip
-          v-if="descriptionTooltip"
-          :delay-duration="0"
-          :ui="{ base: 'h-auto w-auto max-w-sm whitespace-normal text-left' }"
-        >
-          <template #text>
-            <p>{{ descriptionTooltip }}</p>
-          </template>
-          <UIcon
-            name="i-heroicons-information-circle"
-            class="text-muted h-4 w-4 shrink-0"
-            :aria-label="`${title} guidance`"
-          />
-        </UTooltip>
-      </div>
+    </div>
+    <div v-if="description" class="flex items-center gap-1.5 px-6 pb-4">
+      <p class="text-muted text-xs">{{ description }}</p>
+      <UTooltip
+        v-if="descriptionTooltip"
+        :delay-duration="0"
+        :ui="{ base: 'h-auto w-auto max-w-sm whitespace-normal text-left' }"
+      >
+        <template #text>
+          <p>{{ descriptionTooltip }}</p>
+        </template>
+        <UIcon
+          name="i-heroicons-information-circle"
+          class="text-muted h-4 w-4 shrink-0"
+          :aria-label="`${title} guidance`"
+        />
+      </UTooltip>
     </div>
     <div
       v-if="isOpen"

--- a/packages/front-end/src/app/components/EGDashboard.vue
+++ b/packages/front-end/src/app/components/EGDashboard.vue
@@ -18,6 +18,7 @@
   const labStore = useLabsStore();
   const userStore = useUserStore();
   const uiStore = useUiStore();
+  useInitialPendingRequests('loadDashboardData');
   const seqeraPipelinesStore = useSeqeraPipelinesStore();
   const omicsWorkflowsStore = useOmicsWorkflowsStore();
 

--- a/packages/front-end/src/app/components/EGDataCollectionsPage.vue
+++ b/packages/front-end/src/app/components/EGDataCollectionsPage.vue
@@ -33,6 +33,12 @@
   const labsStore = useLabsStore();
   const userStore = useUserStore();
   const uiStore = useUiStore();
+  useInitialPendingRequests(
+    'dataCollectionsTags',
+    'dataCollectionsSamples',
+    'dataCollectionsRunSequenceCollections',
+    'dataCollectionsList',
+  );
   const toast = useToastStore();
 
   type View = 'main' | 'import' | 'builder';
@@ -142,6 +148,7 @@
   function clearUnlinkedFiles(): void {
     unlinkedFiles.value = [];
     unlinkedMeta.value = { s3Bucket: '', resolvedPrefix: '', lastScanLabel: '' };
+    uiStore.setRequestComplete('dataCollectionsList');
   }
 
   async function ensureLabDetailsLoaded(): Promise<void> {

--- a/packages/front-end/src/app/components/EGFileExplorer.vue
+++ b/packages/front-end/src/app/components/EGFileExplorer.vue
@@ -63,7 +63,7 @@
 
   const hasOpenedStartPath = ref(false);
 
-  const isRootLoading = ref(false);
+  const isRootLoading = ref(true);
 
   // Cache for loaded directory contents to avoid re-fetching
   const loadedDirectories = ref<Map<string, FileTreeNode[]>>(new Map());

--- a/packages/front-end/src/app/components/EGFormLabDetails.vue
+++ b/packages/front-end/src/app/components/EGFormLabDetails.vue
@@ -76,7 +76,7 @@
   const formMode = ref(props.formMode);
   const s3Directories = ref([]);
   const isLoadingBuckets = ref(false);
-  const isLoadingFormData = ref(false);
+  const isLoadingFormData = ref(props.formMode !== LabDetailsFormModeEnum.enum.Create);
   const canSubmit = ref(false);
 
   const isEditing = computed<boolean>(() => formMode.value !== LabDetailsFormModeEnum.enum.ReadOnly);
@@ -417,12 +417,10 @@
   }
 
   onMounted(async () => {
-    await getS3Buckets();
-
     if (formMode.value !== LabDetailsFormModeEnum.enum.Create) {
-      await getLabDetails();
-      await loadNotificationPreferences();
+      await Promise.all([getS3Buckets(), getLabDetails(), loadNotificationPreferences()]);
     } else {
+      await getS3Buckets();
       isLoadingNotificationPrefs.value = false;
     }
     switchToFormMode(formMode.value);
@@ -713,7 +711,7 @@
       isEditingGitHubAccessToken.value = false;
       retentionPreviewCacheMonths.value = null;
       retentionPreviewCounts.value = null;
-      await getLabDetails();
+      await getLabDetails({ showLoader: false });
 
       useToastStore().success(`${lab.Name} successfully updated`);
     } catch (error: any) {
@@ -788,7 +786,7 @@
 
     isEditingNextFlowTowerAccessToken.value = false;
     isEditingGitHubAccessToken.value = false;
-    await getLabDetails();
+    await getLabDetails({ showLoader: false });
 
     useToastStore().success(`${lab.Name} successfully updated`);
   }
@@ -996,108 +994,124 @@
 </script>
 
 <template>
-  <div v-if="isLoadingFormData" :aria-busy="true" aria-labelledby="lab-settings-loading-status">
-    <p id="lab-settings-loading-status" class="sr-only" role="status" aria-live="polite">Loading lab settings…</p>
-    <USkeleton class="min-h-96 w-full" aria-hidden="true" />
-  </div>
+  <p v-if="isLoadingFormData" id="lab-settings-loading-status" class="sr-only" role="status" aria-live="polite">
+    Loading lab settings…
+  </p>
   <UForm
-    v-else
     :validate="validate"
     :state="state"
     :aria-labelledby="formMode !== LabDetailsFormModeEnum.enum.Create ? settingsHeadingId : undefined"
-    :aria-busy="isSubmittingFormData || isLoadingRetentionPreview"
+    :aria-busy="isSubmittingFormData || isLoadingRetentionPreview || isLoadingFormData"
+    :aria-describedby="isLoadingFormData ? 'lab-settings-loading-status' : undefined"
     @submit="onSubmit"
   >
     <EGText v-if="formMode !== LabDetailsFormModeEnum.enum.Create" :id="settingsHeadingId" tag="h2" class="sr-only">
       Lab settings
     </EGText>
     <EGCollapsibleSection heading-id="lab-settings-details-heading" title="Lab details" default-open>
-      <!-- Lab Name -->
-      <EGFormGroup label="Lab Name" name="Name" eager-validation required>
-        <EGInput
-          v-model="state.Name"
-          :disabled="!isEditing || isSubmittingFormData"
-          placeholder="Enter lab name (required and must be unique)"
-          autofocus
-        />
-      </EGFormGroup>
+      <div v-if="isLoadingFormData" class="flex flex-col" aria-hidden="true">
+        <div class="mb-6 space-y-2">
+          <USkeleton class="h-4 w-24" />
+          <USkeleton class="h-12 w-full" />
+        </div>
+        <div class="mb-6 space-y-2">
+          <USkeleton class="h-4 w-32" />
+          <USkeleton class="h-20 w-full" />
+        </div>
+        <div v-for="n in 4" :key="n" class="mb-6 space-y-2 last:mb-0">
+          <USkeleton class="h-4 w-48" />
+          <USkeleton class="h-12 w-full" />
+          <USkeleton class="h-3 w-64" />
+        </div>
+      </div>
+      <template v-else>
+        <!-- Lab Name -->
+        <EGFormGroup label="Lab Name" name="Name" eager-validation required>
+          <EGInput
+            v-model="state.Name"
+            :disabled="!isEditing || isSubmittingFormData"
+            placeholder="Enter lab name (required and must be unique)"
+            autofocus
+          />
+        </EGFormGroup>
 
-      <!-- Lab Description -->
-      <EGFormGroup label="Lab Description" name="Description" eager-validation>
-        <EGTextArea
-          v-model="state.Description"
-          :disabled="!isEditing || isSubmittingFormData"
-          placeholder="Describe your lab and what runs should be launched by Lab users."
-        />
-      </EGFormGroup>
+        <!-- Lab Description -->
+        <EGFormGroup label="Lab Description" name="Description" eager-validation>
+          <EGTextArea
+            v-model="state.Description"
+            :disabled="!isEditing || isSubmittingFormData"
+            placeholder="Describe your lab and what runs should be launched by Lab users."
+          />
+        </EGFormGroup>
 
-      <EGFormGroup label="Run retention (months)" name="RunRetentionMonths" eager-validation>
-        <EGInput
-          v-model.number="state.RunRetentionMonths"
-          type="number"
-          min="0"
-          max="120"
-          step="1"
-          :disabled="!isEditing || isSubmittingFormData"
-          placeholder="Enter number of months (0 for never)"
-          :aria-describedby="retentionHelpId"
-        />
-        <p :id="retentionHelpId" class="text-muted mt-1 text-xs">0 = never delete run records</p>
-      </EGFormGroup>
+        <EGFormGroup label="Run retention (months)" name="RunRetentionMonths" eager-validation>
+          <EGInput
+            v-model.number="state.RunRetentionMonths"
+            type="number"
+            min="0"
+            max="120"
+            step="1"
+            :disabled="!isEditing || isSubmittingFormData"
+            placeholder="Enter number of months (0 for never)"
+            :aria-describedby="retentionHelpId"
+          />
+          <p :id="retentionHelpId" class="text-muted mt-1 text-xs">0 = never delete run records</p>
+        </EGFormGroup>
 
-      <EGFormGroup
-        label="Runs list status poll interval (seconds)"
-        name="RunListStatusPollIntervalSeconds"
-        eager-validation
-      >
-        <EGInput
-          v-model.number="state.RunListStatusPollIntervalSeconds"
-          type="number"
-          min="30"
-          max="1800"
-          step="1"
-          :disabled="!isEditing || isSubmittingFormData"
-          placeholder="Enter seconds between list updates"
-          :aria-describedby="runsListPollHelpId"
-        />
-        <p :id="runsListPollHelpId" class="text-muted mt-1 text-xs">
-          Controls how often the lab runs list refreshes run statuses. Allowed range: 30 to 1800 seconds.
-        </p>
-      </EGFormGroup>
+        <EGFormGroup
+          label="Runs list status poll interval (seconds)"
+          name="RunListStatusPollIntervalSeconds"
+          eager-validation
+        >
+          <EGInput
+            v-model.number="state.RunListStatusPollIntervalSeconds"
+            type="number"
+            min="30"
+            max="1800"
+            step="1"
+            :disabled="!isEditing || isSubmittingFormData"
+            placeholder="Enter seconds between list updates"
+            :aria-describedby="runsListPollHelpId"
+          />
+          <p :id="runsListPollHelpId" class="text-muted mt-1 text-xs">
+            Controls how often the lab runs list refreshes run statuses. Allowed range: 30 to 1800 seconds.
+          </p>
+        </EGFormGroup>
 
-      <EGFormGroup
-        label="Run detail progress poll interval (seconds)"
-        name="RunDetailProgressPollIntervalSeconds"
-        eager-validation
-      >
-        <EGInput
-          v-model.number="state.RunDetailProgressPollIntervalSeconds"
-          type="number"
-          min="10"
-          max="300"
-          step="1"
-          :disabled="!isEditing || isSubmittingFormData"
-          placeholder="Enter seconds between run detail updates"
-          :aria-describedby="runDetailPollHelpId"
-        />
-        <p :id="runDetailPollHelpId" class="text-muted mt-1 text-xs">
-          Controls how often the run detail page refreshes task progress. Allowed range: 10 to 300 seconds.
-        </p>
-      </EGFormGroup>
+        <EGFormGroup
+          label="Run detail progress poll interval (seconds)"
+          name="RunDetailProgressPollIntervalSeconds"
+          eager-validation
+        >
+          <EGInput
+            v-model.number="state.RunDetailProgressPollIntervalSeconds"
+            type="number"
+            min="10"
+            max="300"
+            step="1"
+            :disabled="!isEditing || isSubmittingFormData"
+            placeholder="Enter seconds between run detail updates"
+            :aria-describedby="runDetailPollHelpId"
+          />
+          <p :id="runDetailPollHelpId" class="text-muted mt-1 text-xs">
+            Controls how often the run detail page refreshes task progress. Allowed range: 10 to 300 seconds.
+          </p>
+        </EGFormGroup>
 
-      <EGFormGroup v-if="useUserStore().isOrgAdmin()" label="Default S3 bucket directory" name="S3Bucket" required>
-        <EGSelect
-          :options="s3Directories"
-          v-model="selectedS3Bucket"
-          :disabled="!isEditing || isSubmittingFormData"
-          placeholder="Please select an S3 bucket from the list below"
-          searchable-placeholder="Search existing S3 buckets..."
-        />
-        <p v-if="isEditing && persistedBucketNoLongerGranted" class="text-alert-danger-dark mt-1 text-xs">
-          This lab’s previous default bucket ({{ uneditedLabDetails?.S3Bucket }}) is no longer accessible, likely
-          because access was revoked. Select a currently available S3 bucket to continue.
-        </p>
-      </EGFormGroup>
+        <EGFormGroup v-if="useUserStore().isOrgAdmin()" label="Default S3 bucket directory" name="S3Bucket" required>
+          <EGSelect
+            :options="s3Directories"
+            v-model="selectedS3Bucket"
+            :disabled="!isEditing || isSubmittingFormData"
+            placeholder="Please select an S3 bucket from the list below"
+            searchable-placeholder="Search existing S3 buckets..."
+          />
+          <p v-if="isEditing && persistedBucketNoLongerGranted" class="text-alert-danger-dark mt-1 text-xs">
+            This lab’s previous default bucket ({{ uneditedLabDetails?.S3Bucket }}) is no longer accessible, likely
+            because access was revoked. Select a currently available S3 bucket to continue.
+          </p>
+        </EGFormGroup>
+      </template>
     </EGCollapsibleSection>
 
     <div class="mt-6 flex flex-col gap-6">

--- a/packages/front-end/src/app/components/EGFormLabDetails.vue
+++ b/packages/front-end/src/app/components/EGFormLabDetails.vue
@@ -1119,8 +1119,20 @@
         heading-id="lab-settings-integrations-heading"
         title="Integrations"
         description="Seqera and HealthOmics connections for this lab."
-        :badges="integrationsBadges"
+        :badges="isLoadingFormData ? [] : integrationsBadges"
       >
+        <!-- Don't render Seqera/HealthOmics Off from defaultState while lab details are still loading. -->
+        <div v-if="isLoadingFormData" class="flex flex-col" aria-hidden="true">
+          <div class="mb-6 flex items-center justify-between">
+            <USkeleton class="h-4 w-48" />
+            <USkeleton class="h-6 w-12" />
+          </div>
+          <div class="flex items-center justify-between">
+            <USkeleton class="h-4 w-56" />
+            <USkeleton class="h-6 w-12" />
+          </div>
+        </div>
+        <template v-else>
         <section :aria-labelledby="seqeraSectionId">
           <h3 :id="seqeraSectionId" class="sr-only">Seqera integration</h3>
 
@@ -1259,6 +1271,7 @@
             />
           </EGFormGroup>
         </section>
+        </template>
       </EGCollapsibleSection>
 
       <!-- AI Failure Analysis: BYOK per integration. HealthOmics and Seqera each get
@@ -1272,7 +1285,7 @@
         heading-id="lab-settings-ai-failure-analysis-heading"
         title="AI Failure Analysis"
         description="When a run fails, classify the cause by responsible party using an LLM."
-        :badges="[aiFailureAnalysisBadge]"
+        :badges="isLoadingFormData ? [] : [aiFailureAnalysisBadge]"
       >
         <div class="mb-3 flex items-center gap-1.5">
           <p class="text-muted text-xs">
@@ -1456,7 +1469,7 @@
         title="HealthOmics VPC Networking"
         description="Route this lab's HealthOmics runs through a custom VPC configuration."
         description-tooltip="Lets runs reach resources outside the default restricted network — for example internet reference datasets, license servers, or private VPC and on-prem data."
-        :badges="[healthOmicsVpcNetworkingBadge]"
+        :badges="isLoadingFormData ? [] : [healthOmicsVpcNetworkingBadge]"
       >
         <EGFormGroup label="Networking mode" name="AwsHealthOmicsNetworkingMode" eager-validation>
           <div class="mb-2 flex items-center gap-1.5">
@@ -1513,7 +1526,7 @@
         heading-id="lab-settings-run-notifications-heading"
         title="Run Notifications"
         description="Control who gets emailed when runs in this lab finish."
-        :badges="[runNotificationsBadge]"
+        :badges="isLoadingFormData ? [] : [runNotificationsBadge]"
       >
         <!-- Lab-wide kill switch -->
         <EGFormGroup

--- a/packages/front-end/src/app/components/EGFormLabDetails.vue
+++ b/packages/front-end/src/app/components/EGFormLabDetails.vue
@@ -1133,144 +1133,144 @@
           </div>
         </div>
         <template v-else>
-        <section :aria-labelledby="seqeraSectionId">
-          <h3 :id="seqeraSectionId" class="sr-only">Seqera integration</h3>
+          <section :aria-labelledby="seqeraSectionId">
+            <h3 :id="seqeraSectionId" class="sr-only">Seqera integration</h3>
 
-          <!-- Next Flow Tower: Toggle -->
-          <EGFormGroup
-            label="Enable Seqera Integration"
-            name="NextFlowTowerEnable"
-            eager-validation
-            class="flex items-center justify-between"
-          >
-            <label :id="seqeraToggleLabelId" :for="`${seqeraToggleLabelId}-input`" class="sr-only">
-              Enable Seqera Integration
-            </label>
-            <UToggle
-              :id="`${seqeraToggleLabelId}-input`"
-              class="ml-2"
-              v-model="state.NextFlowTowerEnabled"
-              :disabled="!isEditing || isSubmittingFormData"
-              :aria-labelledby="seqeraToggleLabelId"
-            />
-          </EGFormGroup>
-
-          <!-- Next Flow Tower: Endpoint -->
-          <EGFormGroup
-            v-if="state.NextFlowTowerEnabled"
-            label="Seqera Endpoint URL"
-            name="NextFlowTowerApiBaseUrl"
-            eager-validation
-            required
-          >
-            <EGInput v-model="state.NextFlowTowerApiBaseUrl" :disabled="!isEditing || isSubmittingFormData" />
-          </EGFormGroup>
-
-          <!-- Next Flow Tower: Workspace ID -->
-          <EGFormGroup
-            v-if="state.NextFlowTowerEnabled"
-            label="Workspace ID"
-            name="NextFlowTowerWorkspaceId"
-            eager-validation
-          >
-            <EGInput
-              v-model="state.NextFlowTowerWorkspaceId"
-              placeholder="Defaults to the Next Flow Tower personal workspace if not specified."
-              :disabled="!isEditing || isSubmittingFormData"
-            />
-          </EGFormGroup>
-
-          <!-- Next Flow Tower: Access Token -->
-          <EGFormGroup
-            v-if="isEditing && state.NextFlowTowerEnabled"
-            label="Personal Access Token"
-            name="NextFlowTowerAccessToken"
-            eager-validation
-            :required="formMode === LabDetailsFormModeEnum.enum.Create"
-          >
-            <!-- Next Flow Tower: Access Token: Create  Mode -->
-            <EGPasswordInput
-              v-if="formMode === LabDetailsFormModeEnum.enum.Create"
-              v-model="state.NextFlowTowerAccessToken"
-              :password="true"
-              :autocomplete="AutoCompleteOptionsEnum.enum.NewPassword"
-              :disabled="!isEditing || isSubmittingFormData"
-            />
-            <!-- Next Flow Tower: Access Token: Edit  Mode -->
-            <EGPasswordInput
-              v-if="formMode === LabDetailsFormModeEnum.enum.Edit"
-              v-model="state.NextFlowTowerAccessToken"
-              :select-on-focus="true"
-              :password="true"
-              placeholder="Add or update the Next Flow Tower personal access token. Note: A previously set token will never be shown."
-              :show-toggle-password-button="isEditingNextFlowTowerAccessToken"
-              :autocomplete="AutoCompleteOptionsEnum.enum.Off"
+            <!-- Next Flow Tower: Toggle -->
+            <EGFormGroup
+              label="Enable Seqera Integration"
+              name="NextFlowTowerEnable"
               eager-validation
-              :disabled="!isEditing || isSubmittingFormData"
-            />
-          </EGFormGroup>
-        </section>
+              class="flex items-center justify-between"
+            >
+              <label :id="seqeraToggleLabelId" :for="`${seqeraToggleLabelId}-input`" class="sr-only">
+                Enable Seqera Integration
+              </label>
+              <UToggle
+                :id="`${seqeraToggleLabelId}-input`"
+                class="ml-2"
+                v-model="state.NextFlowTowerEnabled"
+                :disabled="!isEditing || isSubmittingFormData"
+                :aria-labelledby="seqeraToggleLabelId"
+              />
+            </EGFormGroup>
 
-        <section :aria-labelledby="healthOmicsSectionId">
-          <h3 :id="healthOmicsSectionId" class="sr-only">HealthOmics integration</h3>
-
-          <!-- HealthOmics Toggle -->
-          <EGFormGroup
-            label="Enable HealthOmics Integration"
-            name="HealthOmicsEnable"
-            eager-validation
-            class="flex items-center justify-between"
-          >
-            <label :id="healthOmicsToggleLabelId" :for="`${healthOmicsToggleLabelId}-input`" class="sr-only">
-              Enable HealthOmics Integration
-            </label>
-            <UToggle
-              :id="`${healthOmicsToggleLabelId}-input`"
-              class="ml-2"
-              v-model="state.AwsHealthOmicsEnabled"
-              :disabled="!isEditing || isSubmittingFormData"
-              :aria-labelledby="healthOmicsToggleLabelId"
-            />
-          </EGFormGroup>
-          <EGFormGroup
-            v-if="isEditing && state.AwsHealthOmicsEnabled"
-            label="GitHub Personal Access Token"
-            name="GitHubAccessToken"
-            eager-validation
-            :required="formMode === LabDetailsFormModeEnum.enum.Create"
-          >
-            <div v-if="formMode === LabDetailsFormModeEnum.enum.Edit" class="mb-2 flex items-center gap-2">
-              <UBadge
-                size="sm"
-                class="bg-alert-danger-muted text-alert-danger rounded-xl border-0 ring-0"
-                aria-hidden="true"
-              >
-                TOKEN SAVED
-              </UBadge>
-              <p class="text-alert-danger-dark text-xs font-medium">
-                Saving a new value will replace the existing token.
-              </p>
-            </div>
-            <EGPasswordInput
-              v-if="formMode === LabDetailsFormModeEnum.enum.Create"
-              v-model="state.GitHubAccessToken"
-              :password="true"
-              :autocomplete="AutoCompleteOptionsEnum.enum.NewPassword"
-              :disabled="!isEditing || isSubmittingFormData"
-            />
-            <EGPasswordInput
-              v-if="formMode === LabDetailsFormModeEnum.enum.Edit"
-              v-model="state.GitHubAccessToken"
-              :select-on-focus="true"
-              :password="true"
-              placeholder="Add or update the GitHub personal access token. Note: A previously set token will never be shown."
-              :show-toggle-password-button="isEditingGitHubAccessToken"
-              :autocomplete="AutoCompleteOptionsEnum.enum.Off"
+            <!-- Next Flow Tower: Endpoint -->
+            <EGFormGroup
+              v-if="state.NextFlowTowerEnabled"
+              label="Seqera Endpoint URL"
+              name="NextFlowTowerApiBaseUrl"
               eager-validation
-              :disabled="!isEditing || isSubmittingFormData"
-            />
-          </EGFormGroup>
-        </section>
+              required
+            >
+              <EGInput v-model="state.NextFlowTowerApiBaseUrl" :disabled="!isEditing || isSubmittingFormData" />
+            </EGFormGroup>
+
+            <!-- Next Flow Tower: Workspace ID -->
+            <EGFormGroup
+              v-if="state.NextFlowTowerEnabled"
+              label="Workspace ID"
+              name="NextFlowTowerWorkspaceId"
+              eager-validation
+            >
+              <EGInput
+                v-model="state.NextFlowTowerWorkspaceId"
+                placeholder="Defaults to the Next Flow Tower personal workspace if not specified."
+                :disabled="!isEditing || isSubmittingFormData"
+              />
+            </EGFormGroup>
+
+            <!-- Next Flow Tower: Access Token -->
+            <EGFormGroup
+              v-if="isEditing && state.NextFlowTowerEnabled"
+              label="Personal Access Token"
+              name="NextFlowTowerAccessToken"
+              eager-validation
+              :required="formMode === LabDetailsFormModeEnum.enum.Create"
+            >
+              <!-- Next Flow Tower: Access Token: Create  Mode -->
+              <EGPasswordInput
+                v-if="formMode === LabDetailsFormModeEnum.enum.Create"
+                v-model="state.NextFlowTowerAccessToken"
+                :password="true"
+                :autocomplete="AutoCompleteOptionsEnum.enum.NewPassword"
+                :disabled="!isEditing || isSubmittingFormData"
+              />
+              <!-- Next Flow Tower: Access Token: Edit  Mode -->
+              <EGPasswordInput
+                v-if="formMode === LabDetailsFormModeEnum.enum.Edit"
+                v-model="state.NextFlowTowerAccessToken"
+                :select-on-focus="true"
+                :password="true"
+                placeholder="Add or update the Next Flow Tower personal access token. Note: A previously set token will never be shown."
+                :show-toggle-password-button="isEditingNextFlowTowerAccessToken"
+                :autocomplete="AutoCompleteOptionsEnum.enum.Off"
+                eager-validation
+                :disabled="!isEditing || isSubmittingFormData"
+              />
+            </EGFormGroup>
+          </section>
+
+          <section :aria-labelledby="healthOmicsSectionId">
+            <h3 :id="healthOmicsSectionId" class="sr-only">HealthOmics integration</h3>
+
+            <!-- HealthOmics Toggle -->
+            <EGFormGroup
+              label="Enable HealthOmics Integration"
+              name="HealthOmicsEnable"
+              eager-validation
+              class="flex items-center justify-between"
+            >
+              <label :id="healthOmicsToggleLabelId" :for="`${healthOmicsToggleLabelId}-input`" class="sr-only">
+                Enable HealthOmics Integration
+              </label>
+              <UToggle
+                :id="`${healthOmicsToggleLabelId}-input`"
+                class="ml-2"
+                v-model="state.AwsHealthOmicsEnabled"
+                :disabled="!isEditing || isSubmittingFormData"
+                :aria-labelledby="healthOmicsToggleLabelId"
+              />
+            </EGFormGroup>
+            <EGFormGroup
+              v-if="isEditing && state.AwsHealthOmicsEnabled"
+              label="GitHub Personal Access Token"
+              name="GitHubAccessToken"
+              eager-validation
+              :required="formMode === LabDetailsFormModeEnum.enum.Create"
+            >
+              <div v-if="formMode === LabDetailsFormModeEnum.enum.Edit" class="mb-2 flex items-center gap-2">
+                <UBadge
+                  size="sm"
+                  class="bg-alert-danger-muted text-alert-danger rounded-xl border-0 ring-0"
+                  aria-hidden="true"
+                >
+                  TOKEN SAVED
+                </UBadge>
+                <p class="text-alert-danger-dark text-xs font-medium">
+                  Saving a new value will replace the existing token.
+                </p>
+              </div>
+              <EGPasswordInput
+                v-if="formMode === LabDetailsFormModeEnum.enum.Create"
+                v-model="state.GitHubAccessToken"
+                :password="true"
+                :autocomplete="AutoCompleteOptionsEnum.enum.NewPassword"
+                :disabled="!isEditing || isSubmittingFormData"
+              />
+              <EGPasswordInput
+                v-if="formMode === LabDetailsFormModeEnum.enum.Edit"
+                v-model="state.GitHubAccessToken"
+                :select-on-focus="true"
+                :password="true"
+                placeholder="Add or update the GitHub personal access token. Note: A previously set token will never be shown."
+                :show-toggle-password-button="isEditingGitHubAccessToken"
+                :autocomplete="AutoCompleteOptionsEnum.enum.Off"
+                eager-validation
+                :disabled="!isEditing || isSubmittingFormData"
+              />
+            </EGFormGroup>
+          </section>
         </template>
       </EGCollapsibleSection>
 
@@ -1287,176 +1287,190 @@
         description="When a run fails, classify the cause by responsible party using an LLM."
         :badges="isLoadingFormData ? [] : [aiFailureAnalysisBadge]"
       >
-        <div class="mb-3 flex items-center gap-1.5">
-          <p class="text-muted text-xs">
-            Documented HealthOmics error codes use a built-in lookup; the LLM only handles ambiguous or free-text cases.
-          </p>
-          <!-- Provider guidance: helps an admin decide which LLM to bring (Bedrock vs OpenAI vs Anthropic)
-               before they pick one in the dropdowns below. -->
-          <UTooltip :delay-duration="0" :ui="{ base: 'h-auto w-auto max-w-sm whitespace-normal text-left' }">
-            <template #text>
-              <div class="space-y-1.5 py-1">
-                <p>
-                  Each integration can use a different provider — for example a cheaper model for high-volume Seqera
-                  traffic, a more accurate model for HealthOmics ambiguous cases.
-                </p>
-                <p class="font-medium text-black">Which provider should I choose?</p>
-                <p>
-                  <span class="font-medium text-black">Amazon Bedrock</span>
-                  — no API key; calls run under the platform's own AWS account and IAM role, not your lab's. Simplest
-                  setup, and the error text stays within AWS, but it isn't isolated to your own AWS account.
-                </p>
-                <p>
-                  <span class="font-medium text-black">Anthropic (Claude)</span>
-                  — best accuracy on nuanced or ambiguous errors. Requires an Anthropic API key.
-                </p>
-                <p>
-                  <span class="font-medium text-black">OpenAI (GPT)</span>
-                  — low-cost small models (e.g. gpt-4o-mini) suited to high-volume traffic. Requires an OpenAI API key.
-                </p>
-                <p class="italic">
-                  OpenAI and Anthropic send the error text to that provider; Bedrock does not leave AWS.
-                </p>
-              </div>
-            </template>
-            <UIcon
-              name="i-heroicons-information-circle"
-              class="text-muted h-4 w-4 shrink-0"
-              aria-label="LLM provider guidance"
-            />
-          </UTooltip>
+        <!-- Don't render provider/enablement state from defaultState while lab details are still loading. -->
+        <div v-if="isLoadingFormData" class="flex flex-col gap-6" aria-hidden="true">
+          <USkeleton class="h-3 w-3/4" />
+          <div v-for="n in 2" :key="n" class="space-y-2">
+            <USkeleton class="h-4 w-32" />
+            <USkeleton class="h-12 w-full" />
+          </div>
         </div>
+        <template v-else>
+          <div class="mb-3 flex items-center gap-1.5">
+            <p class="text-muted text-xs">
+              Documented HealthOmics error codes use a built-in lookup; the LLM only handles ambiguous or free-text
+              cases.
+            </p>
+            <!-- Provider guidance: helps an admin decide which LLM to bring (Bedrock vs OpenAI vs Anthropic)
+               before they pick one in the dropdowns below. -->
+            <UTooltip :delay-duration="0" :ui="{ base: 'h-auto w-auto max-w-sm whitespace-normal text-left' }">
+              <template #text>
+                <div class="space-y-1.5 py-1">
+                  <p>
+                    Each integration can use a different provider — for example a cheaper model for high-volume Seqera
+                    traffic, a more accurate model for HealthOmics ambiguous cases.
+                  </p>
+                  <p class="font-medium text-black">Which provider should I choose?</p>
+                  <p>
+                    <span class="font-medium text-black">Amazon Bedrock</span>
+                    — no API key; calls run under the platform's own AWS account and IAM role, not your lab's. Simplest
+                    setup, and the error text stays within AWS, but it isn't isolated to your own AWS account.
+                  </p>
+                  <p>
+                    <span class="font-medium text-black">Anthropic (Claude)</span>
+                    — best accuracy on nuanced or ambiguous errors. Requires an Anthropic API key.
+                  </p>
+                  <p>
+                    <span class="font-medium text-black">OpenAI (GPT)</span>
+                    — low-cost small models (e.g. gpt-4o-mini) suited to high-volume traffic. Requires an OpenAI API
+                    key.
+                  </p>
+                  <p class="italic">
+                    OpenAI and Anthropic send the error text to that provider; Bedrock does not leave AWS.
+                  </p>
+                </div>
+              </template>
+              <UIcon
+                name="i-heroicons-information-circle"
+                class="text-muted h-4 w-4 shrink-0"
+                aria-label="LLM provider guidance"
+              />
+            </UTooltip>
+          </div>
 
-        <p v-if="!state.AwsHealthOmicsEnabled && !state.NextFlowTowerEnabled" class="text-muted text-xs">
-          Enable HealthOmics or Seqera integration above to configure AI failure analysis for that integration.
-        </p>
+          <p v-if="!state.AwsHealthOmicsEnabled && !state.NextFlowTowerEnabled" class="text-muted text-xs">
+            Enable HealthOmics or Seqera integration above to configure AI failure analysis for that integration.
+          </p>
 
-        <!-- HealthOmics sub-section -->
-        <div v-if="state.AwsHealthOmicsEnabled" class="mb-6 rounded border border-gray-200 p-4">
-          <p class="mb-3 text-sm font-medium text-black">HealthOmics</p>
+          <!-- HealthOmics sub-section -->
+          <div v-if="state.AwsHealthOmicsEnabled" class="mb-6 rounded border border-gray-200 p-4">
+            <p class="mb-3 text-sm font-medium text-black">HealthOmics</p>
 
-          <EGFormGroup label="LLM Provider" name="HealthOmicsLlmProvider" eager-validation>
-            <USelect
-              v-model="state.HealthOmicsLlmProvider"
-              :options="llmProviderOptions"
-              value-attribute="value"
-              option-attribute="label"
-              :disabled="!isEditing || isSubmittingFormData"
-            />
-          </EGFormGroup>
-
-          <EGFormGroup
-            v-if="state.HealthOmicsLlmProvider"
-            label="Model ID"
-            name="HealthOmicsLlmModelId"
-            eager-validation
-            required
-            :hint="modelIdHintFor(state.HealthOmicsLlmProvider)"
-          >
-            <EGInput
-              v-model="state.HealthOmicsLlmModelId"
-              :placeholder="modelIdPlaceholderFor(state.HealthOmicsLlmProvider)"
-              :disabled="!isEditing || isSubmittingFormData"
-            />
-          </EGFormGroup>
-
-          <EGFormGroup
-            v-if="
-              isEditing && (state.HealthOmicsLlmProvider === 'openai' || state.HealthOmicsLlmProvider === 'anthropic')
-            "
-            label="API Key"
-            name="HealthOmicsLlmApiKey"
-            eager-validation
-            :required="formMode === LabDetailsFormModeEnum.enum.Create || !uneditedLabDetails?.HasHealthOmicsLlmApiKey"
-          >
-            <div v-if="uneditedLabDetails?.HasHealthOmicsLlmApiKey" class="mb-2 flex items-center gap-2">
-              <UBadge size="sm" class="bg-alert-danger-muted text-alert-danger rounded-xl border-0 ring-0">
-                KEY SAVED
-              </UBadge>
-              <p class="text-alert-danger-dark text-xs font-medium">
-                Saving a new value will replace the existing key.
-              </p>
-            </div>
-            <EGPasswordInput
-              v-model="state.HealthOmicsLlmApiKey"
-              :select-on-focus="true"
-              :password="true"
-              placeholder="Paste your provider API key. A previously set key is never shown."
-              :autocomplete="AutoCompleteOptionsEnum.enum.NewPassword"
-              :disabled="!isEditing || isSubmittingFormData"
-            />
-          </EGFormGroup>
-
-          <EGFormGroup
-            v-if="state.HealthOmicsLlmProvider"
-            name="HealthOmicsLogEnrichmentEnabled"
-            hint="Sends a redacted excerpt of the failed run's CloudWatch logs to the AI for deeper analysis. Identifiers, paths, and secrets are stripped before sending."
-          >
-            <div class="flex items-center">
-              <span class="text-sm text-black">Analyse run logs on failure</span>
-              <UToggle
-                class="ml-2"
-                v-model="state.HealthOmicsLogEnrichmentEnabled"
+            <EGFormGroup label="LLM Provider" name="HealthOmicsLlmProvider" eager-validation>
+              <USelect
+                v-model="state.HealthOmicsLlmProvider"
+                :options="llmProviderOptions"
+                value-attribute="value"
+                option-attribute="label"
                 :disabled="!isEditing || isSubmittingFormData"
               />
-            </div>
-          </EGFormGroup>
-        </div>
+            </EGFormGroup>
 
-        <!-- Seqera sub-section -->
-        <div v-if="state.NextFlowTowerEnabled" class="mb-6 rounded border border-gray-200 p-4">
-          <p class="mb-3 text-sm font-medium text-black">Seqera</p>
+            <EGFormGroup
+              v-if="state.HealthOmicsLlmProvider"
+              label="Model ID"
+              name="HealthOmicsLlmModelId"
+              eager-validation
+              required
+              :hint="modelIdHintFor(state.HealthOmicsLlmProvider)"
+            >
+              <EGInput
+                v-model="state.HealthOmicsLlmModelId"
+                :placeholder="modelIdPlaceholderFor(state.HealthOmicsLlmProvider)"
+                :disabled="!isEditing || isSubmittingFormData"
+              />
+            </EGFormGroup>
 
-          <EGFormGroup label="LLM Provider" name="SeqeraLlmProvider" eager-validation>
-            <USelect
-              v-model="state.SeqeraLlmProvider"
-              :options="llmProviderOptions"
-              value-attribute="value"
-              option-attribute="label"
-              :disabled="!isEditing || isSubmittingFormData"
-            />
-          </EGFormGroup>
+            <EGFormGroup
+              v-if="
+                isEditing && (state.HealthOmicsLlmProvider === 'openai' || state.HealthOmicsLlmProvider === 'anthropic')
+              "
+              label="API Key"
+              name="HealthOmicsLlmApiKey"
+              eager-validation
+              :required="
+                formMode === LabDetailsFormModeEnum.enum.Create || !uneditedLabDetails?.HasHealthOmicsLlmApiKey
+              "
+            >
+              <div v-if="uneditedLabDetails?.HasHealthOmicsLlmApiKey" class="mb-2 flex items-center gap-2">
+                <UBadge size="sm" class="bg-alert-danger-muted text-alert-danger rounded-xl border-0 ring-0">
+                  KEY SAVED
+                </UBadge>
+                <p class="text-alert-danger-dark text-xs font-medium">
+                  Saving a new value will replace the existing key.
+                </p>
+              </div>
+              <EGPasswordInput
+                v-model="state.HealthOmicsLlmApiKey"
+                :select-on-focus="true"
+                :password="true"
+                placeholder="Paste your provider API key. A previously set key is never shown."
+                :autocomplete="AutoCompleteOptionsEnum.enum.NewPassword"
+                :disabled="!isEditing || isSubmittingFormData"
+              />
+            </EGFormGroup>
 
-          <EGFormGroup
-            v-if="state.SeqeraLlmProvider"
-            label="Model ID"
-            name="SeqeraLlmModelId"
-            eager-validation
-            required
-            :hint="modelIdHintFor(state.SeqeraLlmProvider)"
-          >
-            <EGInput
-              v-model="state.SeqeraLlmModelId"
-              :placeholder="modelIdPlaceholderFor(state.SeqeraLlmProvider)"
-              :disabled="!isEditing || isSubmittingFormData"
-            />
-          </EGFormGroup>
+            <EGFormGroup
+              v-if="state.HealthOmicsLlmProvider"
+              name="HealthOmicsLogEnrichmentEnabled"
+              hint="Sends a redacted excerpt of the failed run's CloudWatch logs to the AI for deeper analysis. Identifiers, paths, and secrets are stripped before sending."
+            >
+              <div class="flex items-center">
+                <span class="text-sm text-black">Analyse run logs on failure</span>
+                <UToggle
+                  class="ml-2"
+                  v-model="state.HealthOmicsLogEnrichmentEnabled"
+                  :disabled="!isEditing || isSubmittingFormData"
+                />
+              </div>
+            </EGFormGroup>
+          </div>
 
-          <EGFormGroup
-            v-if="isEditing && (state.SeqeraLlmProvider === 'openai' || state.SeqeraLlmProvider === 'anthropic')"
-            label="API Key"
-            name="SeqeraLlmApiKey"
-            eager-validation
-            :required="formMode === LabDetailsFormModeEnum.enum.Create || !uneditedLabDetails?.HasSeqeraLlmApiKey"
-          >
-            <div v-if="uneditedLabDetails?.HasSeqeraLlmApiKey" class="mb-2 flex items-center gap-2">
-              <UBadge size="sm" class="bg-alert-danger-muted text-alert-danger rounded-xl border-0 ring-0">
-                KEY SAVED
-              </UBadge>
-              <p class="text-alert-danger-dark text-xs font-medium">
-                Saving a new value will replace the existing key.
-              </p>
-            </div>
-            <EGPasswordInput
-              v-model="state.SeqeraLlmApiKey"
-              :select-on-focus="true"
-              :password="true"
-              placeholder="Paste your provider API key. A previously set key is never shown."
-              :autocomplete="AutoCompleteOptionsEnum.enum.NewPassword"
-              :disabled="!isEditing || isSubmittingFormData"
-            />
-          </EGFormGroup>
-        </div>
+          <!-- Seqera sub-section -->
+          <div v-if="state.NextFlowTowerEnabled" class="mb-6 rounded border border-gray-200 p-4">
+            <p class="mb-3 text-sm font-medium text-black">Seqera</p>
+
+            <EGFormGroup label="LLM Provider" name="SeqeraLlmProvider" eager-validation>
+              <USelect
+                v-model="state.SeqeraLlmProvider"
+                :options="llmProviderOptions"
+                value-attribute="value"
+                option-attribute="label"
+                :disabled="!isEditing || isSubmittingFormData"
+              />
+            </EGFormGroup>
+
+            <EGFormGroup
+              v-if="state.SeqeraLlmProvider"
+              label="Model ID"
+              name="SeqeraLlmModelId"
+              eager-validation
+              required
+              :hint="modelIdHintFor(state.SeqeraLlmProvider)"
+            >
+              <EGInput
+                v-model="state.SeqeraLlmModelId"
+                :placeholder="modelIdPlaceholderFor(state.SeqeraLlmProvider)"
+                :disabled="!isEditing || isSubmittingFormData"
+              />
+            </EGFormGroup>
+
+            <EGFormGroup
+              v-if="isEditing && (state.SeqeraLlmProvider === 'openai' || state.SeqeraLlmProvider === 'anthropic')"
+              label="API Key"
+              name="SeqeraLlmApiKey"
+              eager-validation
+              :required="formMode === LabDetailsFormModeEnum.enum.Create || !uneditedLabDetails?.HasSeqeraLlmApiKey"
+            >
+              <div v-if="uneditedLabDetails?.HasSeqeraLlmApiKey" class="mb-2 flex items-center gap-2">
+                <UBadge size="sm" class="bg-alert-danger-muted text-alert-danger rounded-xl border-0 ring-0">
+                  KEY SAVED
+                </UBadge>
+                <p class="text-alert-danger-dark text-xs font-medium">
+                  Saving a new value will replace the existing key.
+                </p>
+              </div>
+              <EGPasswordInput
+                v-model="state.SeqeraLlmApiKey"
+                :select-on-focus="true"
+                :password="true"
+                placeholder="Paste your provider API key. A previously set key is never shown."
+                :autocomplete="AutoCompleteOptionsEnum.enum.NewPassword"
+                :disabled="!isEditing || isSubmittingFormData"
+              />
+            </EGFormGroup>
+          </div>
+        </template>
       </EGCollapsibleSection>
 
       <!-- HealthOmics VPC Networking: always visible (badge communicates on/off status) so an
@@ -1471,47 +1485,55 @@
         description-tooltip="Lets runs reach resources outside the default restricted network — for example internet reference datasets, license servers, or private VPC and on-prem data."
         :badges="isLoadingFormData ? [] : [healthOmicsVpcNetworkingBadge]"
       >
-        <EGFormGroup label="Networking mode" name="AwsHealthOmicsNetworkingMode" eager-validation>
-          <div class="mb-2 flex items-center gap-1.5">
-            <p class="text-muted text-xs">Only available when HealthOmics is enabled.</p>
-            <UTooltip :delay-duration="0" :ui="{ base: 'h-auto w-auto max-w-sm whitespace-normal text-left' }">
-              <template #text>
-                <p>
-                  Restricted (default) reaches only S3 and ECR in-region. VPC routes this lab's runs through a saved
-                  configuration.
-                </p>
-              </template>
-              <UIcon
-                name="i-heroicons-information-circle"
-                class="text-muted h-4 w-4 shrink-0"
-                aria-label="Networking mode guidance"
-              />
-            </UTooltip>
-          </div>
-          <USelect
-            v-model="state.AwsHealthOmicsNetworkingMode"
-            :options="networkingModeOptions"
-            value-attribute="value"
-            option-attribute="label"
-            :disabled="!isEditing || isSubmittingFormData || !state.AwsHealthOmicsEnabled"
-          />
-        </EGFormGroup>
+        <!-- Don't render the RESTRICTED default from defaultState while lab details are still loading. -->
+        <div v-if="isLoadingFormData" class="space-y-2" aria-hidden="true">
+          <USkeleton class="h-4 w-36" />
+          <USkeleton class="h-3 w-64" />
+          <USkeleton class="h-12 w-full" />
+        </div>
+        <template v-else>
+          <EGFormGroup label="Networking mode" name="AwsHealthOmicsNetworkingMode" eager-validation>
+            <div class="mb-2 flex items-center gap-1.5">
+              <p class="text-muted text-xs">Only available when HealthOmics is enabled.</p>
+              <UTooltip :delay-duration="0" :ui="{ base: 'h-auto w-auto max-w-sm whitespace-normal text-left' }">
+                <template #text>
+                  <p>
+                    Restricted (default) reaches only S3 and ECR in-region. VPC routes this lab's runs through a saved
+                    configuration.
+                  </p>
+                </template>
+                <UIcon
+                  name="i-heroicons-information-circle"
+                  class="text-muted h-4 w-4 shrink-0"
+                  aria-label="Networking mode guidance"
+                />
+              </UTooltip>
+            </div>
+            <USelect
+              v-model="state.AwsHealthOmicsNetworkingMode"
+              :options="networkingModeOptions"
+              value-attribute="value"
+              option-attribute="label"
+              :disabled="!isEditing || isSubmittingFormData || !state.AwsHealthOmicsEnabled"
+            />
+          </EGFormGroup>
 
-        <EGFormGroup
-          v-if="state.AwsHealthOmicsNetworkingMode === 'VPC'"
-          label="VPC configuration name"
-          name="AwsHealthOmicsVpcConfigurationName"
-          eager-validation
-          required
-          hint="Name of an ACTIVE HealthOmics configuration set up by ops."
-        >
-          <EGInput
-            v-model="state.AwsHealthOmicsVpcConfigurationName"
-            maxlength="50"
-            placeholder="wslh-prod-vpc"
-            :disabled="!isEditing || isSubmittingFormData || !state.AwsHealthOmicsEnabled"
-          />
-        </EGFormGroup>
+          <EGFormGroup
+            v-if="state.AwsHealthOmicsNetworkingMode === 'VPC'"
+            label="VPC configuration name"
+            name="AwsHealthOmicsVpcConfigurationName"
+            eager-validation
+            required
+            hint="Name of an ACTIVE HealthOmics configuration set up by ops."
+          >
+            <EGInput
+              v-model="state.AwsHealthOmicsVpcConfigurationName"
+              maxlength="50"
+              placeholder="wslh-prod-vpc"
+              :disabled="!isEditing || isSubmittingFormData || !state.AwsHealthOmicsEnabled"
+            />
+          </EGFormGroup>
+        </template>
       </EGCollapsibleSection>
 
       <!-- Run Notifications: all five controls save via this page's normal Save Changes /
@@ -1528,94 +1550,104 @@
         description="Control who gets emailed when runs in this lab finish."
         :badges="isLoadingFormData ? [] : [runNotificationsBadge]"
       >
-        <!-- Lab-wide kill switch -->
-        <EGFormGroup
-          name="NotificationsEnabled"
-          eager-validation
-          hint="Turns off run-completion emails for everyone in this lab and disables the preferences below until this is re-enabled."
-        >
+        <!-- Don't render the lab-wide kill switch from defaultState while lab details are still loading. -->
+        <div v-if="isLoadingFormData" class="flex flex-col gap-6" aria-hidden="true">
           <div class="flex items-center justify-between">
-            <label
-              :id="notificationsToggleLabelId"
-              :for="`${notificationsToggleLabelId}-input`"
-              class="text-sm text-black"
-            >
-              Enable email notifications for this lab
-            </label>
-            <UToggle
-              :id="`${notificationsToggleLabelId}-input`"
-              class="ml-2"
-              v-model="state.NotificationsEnabled"
-              :disabled="!isEditing || isSubmittingFormData"
-              :aria-labelledby="notificationsToggleLabelId"
-            />
+            <USkeleton class="h-4 w-64" />
+            <USkeleton class="h-6 w-12" />
           </div>
-        </EGFormGroup>
-
-        <USkeleton v-if="isLoadingNotificationPrefs" class="mt-4 h-24 w-full" aria-hidden="true" />
+          <USkeleton class="h-24 w-full" />
+        </div>
         <template v-else>
-          <!-- Per-user preferences: staged locally like every other field, saved via Save Changes -->
-          <EGFormGroup name="NotifyOnOwnRuns" eager-validation>
+          <!-- Lab-wide kill switch -->
+          <EGFormGroup
+            name="NotificationsEnabled"
+            eager-validation
+            hint="Turns off run-completion emails for everyone in this lab and disables the preferences below until this is re-enabled."
+          >
             <div class="flex items-center justify-between">
-              <span :id="notifyOwnRunsToggleLabelId" class="text-sm text-black">Email me about my own runs</span>
+              <label
+                :id="notificationsToggleLabelId"
+                :for="`${notificationsToggleLabelId}-input`"
+                class="text-sm text-black"
+              >
+                Enable email notifications for this lab
+              </label>
               <UToggle
+                :id="`${notificationsToggleLabelId}-input`"
                 class="ml-2"
-                v-model="notifyOnOwnRunsEnabled"
-                :disabled="runNotificationPreferencesDisabled"
-                :aria-labelledby="notifyOwnRunsToggleLabelId"
+                v-model="state.NotificationsEnabled"
+                :disabled="!isEditing || isSubmittingFormData"
+                :aria-labelledby="notificationsToggleLabelId"
               />
             </div>
           </EGFormGroup>
 
-          <EGFormGroup name="NotifyOnLabRuns" eager-validation>
-            <div class="flex items-center justify-between">
-              <span :id="notifyLabRunsToggleLabelId" class="text-sm text-black">
-                Email me about all runs in this lab
-              </span>
-              <UToggle
-                class="ml-2"
-                v-model="notifyOnLabRunsEnabled"
-                :disabled="runNotificationPreferencesDisabled"
-                :aria-labelledby="notifyLabRunsToggleLabelId"
-              />
-            </div>
-          </EGFormGroup>
+          <USkeleton v-if="isLoadingNotificationPrefs" class="mt-4 h-24 w-full" aria-hidden="true" />
+          <template v-else>
+            <!-- Per-user preferences: staged locally like every other field, saved via Save Changes -->
+            <EGFormGroup name="NotifyOnOwnRuns" eager-validation>
+              <div class="flex items-center justify-between">
+                <span :id="notifyOwnRunsToggleLabelId" class="text-sm text-black">Email me about my own runs</span>
+                <UToggle
+                  class="ml-2"
+                  v-model="notifyOnOwnRunsEnabled"
+                  :disabled="runNotificationPreferencesDisabled"
+                  :aria-labelledby="notifyOwnRunsToggleLabelId"
+                />
+              </div>
+            </EGFormGroup>
 
-          <EGFormGroup v-if="notifyOnLabRunsEnabled" name="NotifyOnLabRunsAdditionalEmailsInput" eager-validation>
-            <label :for="notifyLabRunsAdditionalEmailsInputId" class="mb-1 block text-sm text-black">
-              Also CC these emails on every lab run
-            </label>
-            <EGInput
-              :id="notifyLabRunsAdditionalEmailsInputId"
-              v-model="notifyOnLabRunsAdditionalEmailsInput"
-              placeholder="team-distro@example.com, oncall@example.com"
-              :disabled="runNotificationPreferencesDisabled"
-            />
-            <p v-if="additionalEmailsError" class="text-alert-danger-dark mt-1 text-xs font-medium">
-              {{ additionalEmailsError }}
-            </p>
-            <p v-else class="text-muted mt-1 text-xs">
-              Comma-separated, up to 10. Sent whenever your own "all runs in this lab" notification fires.
-            </p>
-          </EGFormGroup>
+            <EGFormGroup name="NotifyOnLabRuns" eager-validation>
+              <div class="flex items-center justify-between">
+                <span :id="notifyLabRunsToggleLabelId" class="text-sm text-black">
+                  Email me about all runs in this lab
+                </span>
+                <UToggle
+                  class="ml-2"
+                  v-model="notifyOnLabRunsEnabled"
+                  :disabled="runNotificationPreferencesDisabled"
+                  :aria-labelledby="notifyLabRunsToggleLabelId"
+                />
+              </div>
+            </EGFormGroup>
 
-          <EGFormGroup v-if="showNotificationEventFilter" name="NotificationEventFilter" eager-validation>
-            <p class="mb-2 text-sm text-black">Notify me when a run</p>
-            <div class="flex flex-col gap-2">
-              <UCheckbox
-                label="Succeeds"
-                :model-value="eventFilterSuccessChecked"
+            <EGFormGroup v-if="notifyOnLabRunsEnabled" name="NotifyOnLabRunsAdditionalEmailsInput" eager-validation>
+              <label :for="notifyLabRunsAdditionalEmailsInputId" class="mb-1 block text-sm text-black">
+                Also CC these emails on every lab run
+              </label>
+              <EGInput
+                :id="notifyLabRunsAdditionalEmailsInputId"
+                v-model="notifyOnLabRunsAdditionalEmailsInput"
+                placeholder="team-distro@example.com, oncall@example.com"
                 :disabled="runNotificationPreferencesDisabled"
-                @update:model-value="onToggleNotifySuccesses"
               />
-              <UCheckbox
-                label="Fails"
-                :model-value="eventFilterFailureChecked"
-                :disabled="runNotificationPreferencesDisabled"
-                @update:model-value="onToggleNotifyFailures"
-              />
-            </div>
-          </EGFormGroup>
+              <p v-if="additionalEmailsError" class="text-alert-danger-dark mt-1 text-xs font-medium">
+                {{ additionalEmailsError }}
+              </p>
+              <p v-else class="text-muted mt-1 text-xs">
+                Comma-separated, up to 10. Sent whenever your own "all runs in this lab" notification fires.
+              </p>
+            </EGFormGroup>
+
+            <EGFormGroup v-if="showNotificationEventFilter" name="NotificationEventFilter" eager-validation>
+              <p class="mb-2 text-sm text-black">Notify me when a run</p>
+              <div class="flex flex-col gap-2">
+                <UCheckbox
+                  label="Succeeds"
+                  :model-value="eventFilterSuccessChecked"
+                  :disabled="runNotificationPreferencesDisabled"
+                  @update:model-value="onToggleNotifySuccesses"
+                />
+                <UCheckbox
+                  label="Fails"
+                  :model-value="eventFilterFailureChecked"
+                  :disabled="runNotificationPreferencesDisabled"
+                  @update:model-value="onToggleNotifyFailures"
+                />
+              </div>
+            </EGFormGroup>
+          </template>
         </template>
       </EGCollapsibleSection>
     </div>

--- a/packages/front-end/src/app/components/EGLabView.vue
+++ b/packages/front-end/src/app/components/EGLabView.vue
@@ -36,6 +36,7 @@
   const runStore = useRunStore();
   const labStore = useLabsStore();
   const uiStore = useUiStore();
+  useInitialPendingRequests('loadLabData');
   const userStore = useUserStore();
   const seqeraPipelinesStore = useSeqeraPipelinesStore();
   const omicsWorkflowsStore = useOmicsWorkflowsStore();
@@ -911,6 +912,7 @@
       :show-back="true"
       show-org-breadcrumb
       show-lab-breadcrumb
+      :is-loading="uiStore.isRequestPending('loadLabData')"
     >
       <EGButton
         v-if="!superuser && activeTabKey === 'omicsWorkflows' && canCreateOmicsWorkflows"

--- a/packages/front-end/src/app/components/EGLabsList.vue
+++ b/packages/front-end/src/app/components/EGLabsList.vue
@@ -13,6 +13,8 @@
   const router = useRouter();
   const labsStore = useLabsStore();
 
+  useInitialPendingRequests('getLabs');
+
   const labsDisplayList = computed<Laboratory[]>(() =>
     labsStore.labsForOrg(props.orgId).sort((labA, labB) => useSort().stringSortCompare(labA.Name, labB.Name)),
   );

--- a/packages/front-end/src/app/components/EGOrgView.vue
+++ b/packages/front-end/src/app/components/EGOrgView.vue
@@ -30,6 +30,9 @@
 
   const hasNoData = computed<boolean>(() => orgUsersDetailsData.value.length === 0);
   const isLoading = computed<boolean>(() => useUiStore().anyRequestPending(['fetchOrgData', 'editOrg']));
+  const isFetchingOrg = computed<boolean>(() => useUiStore().isRequestPending('fetchOrgData'));
+
+  useInitialPendingRequests('fetchOrgData');
 
   // Dynamic remove user dialog values
   const isRemoveUserModalOpen = ref(false);
@@ -457,6 +460,7 @@
   <div v-if="activeTabKey === 'details'" role="tabpanel" id="panel-details" aria-labelledby="tab-details" tabindex="0">
     <h2 class="sr-only">Organization settings</h2>
     <EGFormOrgDetails
+      v-if="!isFetchingOrg"
       :key="resetFormKey"
       @submit-form-org-details="onSubmit($event)"
       :name="org.Name"
@@ -475,6 +479,7 @@
   >
     <h2 class="sr-only">Email branding</h2>
     <EGFormOrgEmailBranding
+      v-if="!isFetchingOrg"
       :key="resetFormKey"
       :org-id="props.orgId"
       :email-branding-logo-url="org.EmailBrandingLogoUrl"

--- a/packages/front-end/src/app/components/EGOrgsList.vue
+++ b/packages/front-end/src/app/components/EGOrgsList.vue
@@ -25,7 +25,7 @@
   onBeforeMount(loadOrgs);
 
   // table data stuff
-  const isLoading = ref(false);
+  const isLoading = ref(true);
   const orgsDisplayList = computed<Organization[]>(() =>
     Object.values(orgsStore.orgs).sort((orgA, orgB) => useSort().stringSortCompare(orgA.Name, orgB.Name)),
   );

--- a/packages/front-end/src/app/components/EGUserAccessPanel.vue
+++ b/packages/front-end/src/app/components/EGUserAccessPanel.vue
@@ -15,6 +15,8 @@
   const { $api } = useNuxtApp();
   const $router = useRouter();
 
+  useInitialPendingRequests('updateUser', 'fetchOrgLabs', 'fetchUserLabs');
+
   const selectedUser = ref<OrganizationUserDetails | null>(null);
 
   const selectedUserNameDetails = computed<NameOptions>(() => ({

--- a/packages/front-end/src/app/components/EGWorkflowPresets.vue
+++ b/packages/front-end/src/app/components/EGWorkflowPresets.vue
@@ -23,6 +23,7 @@
 
   const presetsStore = useWorkflowRunPresetsStore();
   const uiStore = useUiStore();
+  useInitialPendingRequests('loadWorkflowRunPresets');
   const toast = useToastStore();
 
   const appliedPresetId = ref<string | null>(null);

--- a/packages/front-end/src/app/composables/useInitialPendingRequests.ts
+++ b/packages/front-end/src/app/composables/useInitialPendingRequests.ts
@@ -1,0 +1,13 @@
+import type { PendingRequest } from '@FE/stores/ui';
+
+/**
+ * Mark UI-store requests as pending during setup so the first render is a
+ * loading state. Vue paints once before onBeforeMount/onMounted, so setting
+ * pending only inside those hooks flashes content, then a skeleton, then content.
+ */
+export function useInitialPendingRequests(...keys: PendingRequest[]): void {
+  const uiStore = useUiStore();
+  for (const key of keys) {
+    uiStore.setRequestPending(key);
+  }
+}

--- a/packages/front-end/src/app/pages/labs/[labId]/create-workflow.vue
+++ b/packages/front-end/src/app/pages/labs/[labId]/create-workflow.vue
@@ -13,6 +13,10 @@
     $router.push('/labs');
   }
 
+  if (!labsStore.labs[labId]) {
+    uiStore.setRequestPending('loadLabData');
+  }
+
   onBeforeMount(async () => {
     if (!labsStore.labs[labId]) {
       uiStore.setRequestPending('loadLabData');

--- a/packages/front-end/src/app/pages/labs/[labId]/omics-run/[omicsRunId].vue
+++ b/packages/front-end/src/app/pages/labs/[labId]/omics-run/[omicsRunId].vue
@@ -29,6 +29,8 @@
 
   const omicsRun = computed<OmicsRun | null>(() => runStore.omicsRuns[labId][omicsRunId]);
 
+  useInitialPendingRequests('loadOmicsRun');
+
   usePageTitle(() => (omicsRun.value?.name ? omicsRun.value.name : 'HealthOmics run'));
 
   const createdDateTime = computed(() => {
@@ -53,7 +55,13 @@
     tabIndex.value = queryTabMatchIndex !== -1 ? queryTabMatchIndex : 0;
   });
 
-  onBeforeMount(async () => await runStore.loadSingleOmicsRun(labId, omicsRunId));
+  onBeforeMount(async () => {
+    try {
+      await runStore.loadSingleOmicsRun(labId, omicsRunId);
+    } finally {
+      useUiStore().setRequestComplete('loadOmicsRun');
+    }
+  });
 
   watch(tabIndex, (index) => {
     if (index === 1) useToastStore().info('Viewing HealthOmics Run results is not yet implemented');

--- a/packages/front-end/src/app/pages/labs/[labId]/run-pipeline/[pipelineId].vue
+++ b/packages/front-end/src/app/pages/labs/[labId]/run-pipeline/[pipelineId].vue
@@ -18,6 +18,7 @@
   const labsStore = useLabsStore();
   const userStore = useUserStore();
   const uiStore = useUiStore();
+  useInitialPendingRequests('loadSeqeraPipeline');
 
   const labId = $route.params.labId as string;
   const pipelineId = $route.params.pipelineId as string;

--- a/packages/front-end/src/app/pages/labs/[labId]/run-pipeline/[pipelineId].vue
+++ b/packages/front-end/src/app/pages/labs/[labId]/run-pipeline/[pipelineId].vue
@@ -26,11 +26,13 @@
 
   // check permissions to be on this page
   if (!userStore.canViewLab(labId)) {
+    uiStore.setRequestComplete('loadSeqeraPipeline');
     $router.push('/labs');
   }
 
   onBeforeMount(async () => {
     if (await ensureLabInActiveOrg({ labId, forceReload: true })) {
+      uiStore.setRequestComplete('loadSeqeraPipeline');
       return;
     }
   });
@@ -125,95 +127,97 @@
   async function initialize() {
     uiStore.setRequestPending('loadSeqeraPipeline');
 
-    // reset state refs
-    hasLaunched.value = false;
-    selectedStepIndex.value = 0;
+    try {
+      // reset state refs
+      hasLaunched.value = false;
+      selectedStepIndex.value = 0;
 
-    schema.value = {};
-    initialParams.value = {};
+      schema.value = {};
+      initialParams.value = {};
 
-    steps.value.forEach((step) => (step.disabled = true));
-    steps.value[0].disabled = false;
+      steps.value.forEach((step) => (step.disabled = true));
+      steps.value[0].disabled = false;
 
-    // get pipeline schema from API
-    const pipelineSchemaResponse: DescribePipelineSchemaResponse = await $api.seqeraPipelines.readPipelineSchema(
-      parseInt(pipelineId),
-      labId,
-    );
-    const originalSchema = JSON.parse(pipelineSchemaResponse.schema);
+      // get pipeline schema from API
+      const pipelineSchemaResponse: DescribePipelineSchemaResponse = await $api.seqeraPipelines.readPipelineSchema(
+        parseInt(pipelineId),
+        labId,
+      );
+      const originalSchema = JSON.parse(pipelineSchemaResponse.schema);
 
-    const definitions = originalSchema.$defs || originalSchema.definitions;
+      const definitions = originalSchema.$defs || originalSchema.definitions;
 
-    // Filter Schema to exclude any sections that do not have any visible parameters for user input
-    const filteredDefinitions = Object.keys(definitions)
-      .flatMap((key) => {
-        const section = definitions[key];
-        const hasAllHiddenSettings: boolean = Object.values(section.properties).every((x) => x?.hidden === true);
-        if (!hasAllHiddenSettings) {
-          return {
-            [key]: section,
-          };
+      // Filter Schema to exclude any sections that do not have any visible parameters for user input
+      const filteredDefinitions = Object.keys(definitions)
+        .flatMap((key) => {
+          const section = definitions[key];
+          const hasAllHiddenSettings: boolean = Object.values(section.properties).every((x) => x?.hidden === true);
+          if (!hasAllHiddenSettings) {
+            return {
+              [key]: section,
+            };
+          }
+        })
+        .filter((_) => _)
+        .reduce((acc, cur) => ({ ...acc, [Object.keys(cur)[0]]: Object.values(cur)[0] }), {});
+
+      // Identify Seqera pipeline schema required parameters
+      const paramsRequired: string[] = definitions.input_output_options.required
+        ? definitions.input_output_options.required
+        : [];
+
+      schema.value = {
+        ...originalSchema,
+        $defs: filteredDefinitions,
+      };
+
+      // create an object with all non-hidden fields' default values
+      function defaultVal(type: 'string' | 'number' | 'boolean'): '' | 0 | false {
+        switch (type) {
+          case 'string':
+            return '';
+          case 'number':
+            return 0;
+          case 'boolean':
+            return false;
         }
-      })
-      .filter((_) => _)
-      .reduce((acc, cur) => ({ ...acc, [Object.keys(cur)[0]]: Object.values(cur)[0] }), {});
-
-    // Identify Seqera pipeline schema required parameters
-    const paramsRequired: string[] = definitions.input_output_options.required
-      ? definitions.input_output_options.required
-      : [];
-
-    schema.value = {
-      ...originalSchema,
-      $defs: filteredDefinitions,
-    };
-
-    // create an object with all non-hidden fields' default values
-    function defaultVal(type: 'string' | 'number' | 'boolean'): '' | 0 | false {
-      switch (type) {
-        case 'string':
-          return '';
-        case 'number':
-          return 0;
-        case 'boolean':
-          return false;
       }
-    }
-    const schemaDefaults: any = {};
-    for (const sectionKey of Object.keys(filteredDefinitions)) {
-      const section: any = filteredDefinitions[sectionKey];
-      for (const propertyKey of Object.keys(section.properties)) {
-        const property: any = section.properties[propertyKey];
-        schemaDefaults[propertyKey] = defaultVal(property.type);
+      const schemaDefaults: any = {};
+      for (const sectionKey of Object.keys(filteredDefinitions)) {
+        const section: any = filteredDefinitions[sectionKey];
+        for (const propertyKey of Object.keys(section.properties)) {
+          const property: any = section.properties[propertyKey];
+          schemaDefaults[propertyKey] = defaultVal(property.type);
+        }
       }
+
+      // initialize wip run with values
+      runStore.updateWipSeqeraRun(seqeraRunTempId.value, {
+        transactionId: seqeraRunTempId.value,
+        paramsRequired: paramsRequired,
+      });
+
+      const existingWip = runStore.wipSeqeraRuns[seqeraRunTempId.value];
+
+      // initialize params and save so that they can be easily reset
+      initialParams.value = {
+        ...schemaDefaults, // default values for all non-hidden fields
+        ...JSON.parse(pipelineSchemaResponse.params!), // overwrite with values from the pipeline schema
+        input: '', // clear the default sample sheet github link that comes from the pipeline itself
+      };
+
+      const paramsToApply = JSON.parse(JSON.stringify(initialParams.value));
+      if (existingWip?.sampleSheetS3Url && existingWip?.params?.input) {
+        paramsToApply.input = existingWip.params.input;
+        paramsToApply.outdir = existingWip.params.outdir;
+      }
+
+      runStore.updateWipSeqeraRunParams(seqeraRunTempId.value, paramsToApply);
+
+      await applySequenceCollectionsPrepopulation();
+    } finally {
+      uiStore.setRequestComplete('loadSeqeraPipeline');
     }
-
-    // initialize wip run with values
-    runStore.updateWipSeqeraRun(seqeraRunTempId.value, {
-      transactionId: seqeraRunTempId.value,
-      paramsRequired: paramsRequired,
-    });
-
-    const existingWip = runStore.wipSeqeraRuns[seqeraRunTempId.value];
-
-    // initialize params and save so that they can be easily reset
-    initialParams.value = {
-      ...schemaDefaults, // default values for all non-hidden fields
-      ...JSON.parse(pipelineSchemaResponse.params!), // overwrite with values from the pipeline schema
-      input: '', // clear the default sample sheet github link that comes from the pipeline itself
-    };
-
-    const paramsToApply = JSON.parse(JSON.stringify(initialParams.value));
-    if (existingWip?.sampleSheetS3Url && existingWip?.params?.input) {
-      paramsToApply.input = existingWip.params.input;
-      paramsToApply.outdir = existingWip.params.outdir;
-    }
-
-    runStore.updateWipSeqeraRunParams(seqeraRunTempId.value, paramsToApply);
-
-    await applySequenceCollectionsPrepopulation();
-
-    uiStore.setRequestComplete('loadSeqeraPipeline');
   }
 
   /** When opened from Data Collections with a pre-built sample sheet, skip to parameter configuration. */

--- a/packages/front-end/src/app/pages/labs/[labId]/run-workflow/[workflowId].vue
+++ b/packages/front-end/src/app/pages/labs/[labId]/run-workflow/[workflowId].vue
@@ -14,6 +14,7 @@
   const runStore = useRunStore();
   const omicsWorkflowsStore = useOmicsWorkflowsStore();
   const uiStore = useUiStore();
+  useInitialPendingRequests('loadOmicsWorkflow');
   const userStore = useUserStore();
   const labsStore = useLabsStore();
 

--- a/packages/front-end/src/app/pages/labs/[labId]/run-workflow/[workflowId].vue
+++ b/packages/front-end/src/app/pages/labs/[labId]/run-workflow/[workflowId].vue
@@ -24,11 +24,13 @@
 
   // check permissions to be on this page
   if (!userStore.canViewLab(labId)) {
+    uiStore.setRequestComplete('loadOmicsWorkflow');
     $router.push('/labs');
   }
 
   onBeforeMount(async () => {
     if (await ensureLabInActiveOrg({ labId, forceReload: true })) {
+      uiStore.setRequestComplete('loadOmicsWorkflow');
       return;
     }
   });
@@ -150,96 +152,98 @@
   async function initialize() {
     uiStore.setRequestPending('loadOmicsWorkflow');
 
-    // reset state refs
-    hasLaunched.value = false;
-    selectedStepIndex.value = 0;
-
-    steps.value.forEach((step) => (step.disabled = true));
-    steps.value[0].disabled = false;
-
-    // get full workflow details from API and save them in the store
-    const cachedOwnerId = omicsWorkflowsStore.workflows[workflowId]?.ownerAccountId;
-    const omicsWorkflow: ReadWorkflow = await $api.omicsWorkflows.get(labId, workflowId, cachedOwnerId);
-    omicsWorkflowsStore.workflows[workflowId] = {
-      ...omicsWorkflowsStore.workflows[workflowId],
-      ...omicsWorkflow,
-      ...(cachedOwnerId ? { ownerAccountId: cachedOwnerId } : {}),
-    };
-
     try {
-      const versionsRes = await $api.omicsWorkflows.listVersions(labId, workflowId, cachedOwnerId);
-      const names = (versionsRes.items ?? [])
-        .map((v) => v.versionName)
-        .filter((n): n is string => !!n)
-        .sort((a, b) => a.localeCompare(b));
-      if (names.length > 0) {
-        workflowVersionOptions.value = [
-          { value: OMICS_DEFAULT_WORKFLOW_VERSION, label: 'Default version' },
-          ...names.map((n) => ({ value: n, label: n })),
-        ];
-      } else {
+      // reset state refs
+      hasLaunched.value = false;
+      selectedStepIndex.value = 0;
+
+      steps.value.forEach((step) => (step.disabled = true));
+      steps.value[0].disabled = false;
+
+      // get full workflow details from API and save them in the store
+      const cachedOwnerId = omicsWorkflowsStore.workflows[workflowId]?.ownerAccountId;
+      const omicsWorkflow: ReadWorkflow = await $api.omicsWorkflows.get(labId, workflowId, cachedOwnerId);
+      omicsWorkflowsStore.workflows[workflowId] = {
+        ...omicsWorkflowsStore.workflows[workflowId],
+        ...omicsWorkflow,
+        ...(cachedOwnerId ? { ownerAccountId: cachedOwnerId } : {}),
+      };
+
+      try {
+        const versionsRes = await $api.omicsWorkflows.listVersions(labId, workflowId, cachedOwnerId);
+        const names = (versionsRes.items ?? [])
+          .map((v) => v.versionName)
+          .filter((n): n is string => !!n)
+          .sort((a, b) => a.localeCompare(b));
+        if (names.length > 0) {
+          workflowVersionOptions.value = [
+            { value: OMICS_DEFAULT_WORKFLOW_VERSION, label: 'Default version' },
+            ...names.map((n) => ({ value: n, label: n })),
+          ];
+        } else {
+          workflowVersionOptions.value = undefined;
+        }
+      } catch {
         workflowVersionOptions.value = undefined;
       }
-    } catch {
-      workflowVersionOptions.value = undefined;
-    }
 
-    // GetWorkflowResponse.parameterTemplate is optional per the AWS SDK type — HealthOmics can
-    // legitimately return a workflow with no parameter template (e.g. one that takes no params).
-    const parameterTemplate = omicsWorkflow.parameterTemplate ?? {};
+      // GetWorkflowResponse.parameterTemplate is optional per the AWS SDK type — HealthOmics can
+      // legitimately return a workflow with no parameter template (e.g. one that takes no params).
+      const parameterTemplate = omicsWorkflow.parameterTemplate ?? {};
 
-    // Identify AWS HealthOmics workflow schema required parameters
-    const paramsRequired: string[] = Object.entries(parameterTemplate)
-      .map((param: [string, object]) => {
-        const paramName: string = param[0];
-        const paramDetails: any = param[1];
+      // Identify AWS HealthOmics workflow schema required parameters
+      const paramsRequired: string[] = Object.entries(parameterTemplate)
+        .map((param: [string, object]) => {
+          const paramName: string = param[0];
+          const paramDetails: any = param[1];
 
-        if (paramDetails.optional === false) {
-          return paramName;
+          if (paramDetails.optional === false) {
+            return paramName;
+          }
+        })
+        .filter((_) => _ != undefined);
+
+      // fetch user defaults for this workflow (if any), scoped to current parameter template keys
+      const userId = userStore.currentUserDetails.id;
+      let workflowDefaultParams: Record<string, unknown> = {};
+      let rawSavedDefaults: Record<string, unknown> = {};
+      if (userId) {
+        const user = await $api.users.getUser();
+        rawSavedDefaults = user.OmicsWorkflowDefaultParams?.[workflowId] ?? {};
+        workflowDefaultParams = Object.fromEntries(
+          Object.entries(rawSavedDefaults).filter(([paramName]) =>
+            Object.prototype.hasOwnProperty.call(parameterTemplate, paramName),
+          ),
+        );
+      }
+      hasOmicsWorkflowSavedParameterDefaults.value =
+        typeof rawSavedDefaults === 'object' && Object.keys(rawSavedDefaults).length > 0;
+
+      if (retryFromRunId.value) {
+        // Retry: seed the wip run from the failed run instead of the user's saved defaults.
+        await prefillFromFailedRun(paramsRequired);
+      } else {
+        // initialize wip run in store
+        runStore.updateWipOmicsRun(omicsRunTempId.value, {
+          transactionId: omicsRunTempId.value,
+          paramsRequired: paramsRequired,
+        });
+
+        const existingWip = runStore.wipOmicsRuns[omicsRunTempId.value];
+        const paramsToApply = { ...workflowDefaultParams };
+        if (existingWip?.params?.input) {
+          paramsToApply.input = existingWip.params.input;
         }
-      })
-      .filter((_) => _ != undefined);
+        if (existingWip?.params?.outdir) {
+          paramsToApply.outdir = existingWip.params.outdir;
+        }
+        runStore.updateWipOmicsRunParams(omicsRunTempId.value, paramsToApply);
 
-    // fetch user defaults for this workflow (if any), scoped to current parameter template keys
-    const userId = userStore.currentUserDetails.id;
-    let workflowDefaultParams: Record<string, unknown> = {};
-    let rawSavedDefaults: Record<string, unknown> = {};
-    if (userId) {
-      const user = await $api.users.getUser();
-      rawSavedDefaults = user.OmicsWorkflowDefaultParams?.[workflowId] ?? {};
-      workflowDefaultParams = Object.fromEntries(
-        Object.entries(rawSavedDefaults).filter(([paramName]) =>
-          Object.prototype.hasOwnProperty.call(parameterTemplate, paramName),
-        ),
-      );
-    }
-    hasOmicsWorkflowSavedParameterDefaults.value =
-      typeof rawSavedDefaults === 'object' && Object.keys(rawSavedDefaults).length > 0;
-
-    if (retryFromRunId.value) {
-      // Retry: seed the wip run from the failed run instead of the user's saved defaults.
-      await prefillFromFailedRun(paramsRequired);
-    } else {
-      // initialize wip run in store
-      runStore.updateWipOmicsRun(omicsRunTempId.value, {
-        transactionId: omicsRunTempId.value,
-        paramsRequired: paramsRequired,
-      });
-
-      const existingWip = runStore.wipOmicsRuns[omicsRunTempId.value];
-      const paramsToApply = { ...workflowDefaultParams };
-      if (existingWip?.params?.input) {
-        paramsToApply.input = existingWip.params.input;
+        await applySequenceCollectionsPrepopulation();
       }
-      if (existingWip?.params?.outdir) {
-        paramsToApply.outdir = existingWip.params.outdir;
-      }
-      runStore.updateWipOmicsRunParams(omicsRunTempId.value, paramsToApply);
-
-      await applySequenceCollectionsPrepopulation();
+    } finally {
+      uiStore.setRequestComplete('loadOmicsWorkflow');
     }
-
-    uiStore.setRequestComplete('loadOmicsWorkflow');
   }
 
   /** When opened from Data Collections with a pre-built sample sheet, skip to parameter configuration. */

--- a/packages/front-end/src/app/pages/labs/[labId]/run/[labRunId].vue
+++ b/packages/front-end/src/app/pages/labs/[labId]/run/[labRunId].vue
@@ -26,6 +26,7 @@
   const labsStore = useLabsStore();
   const runStore = useRunStore();
   const uiStore = useUiStore();
+  useInitialPendingRequests('loadLabRuns');
 
   const labId = $route.params.labId as string;
   const labRunId = $route.params.labRunId as string;
@@ -104,6 +105,7 @@
 
   onBeforeMount(async () => {
     if (await ensureLabInActiveOrg({ labId, forceReload: true })) {
+      uiStore.setRequestComplete('loadLabRuns');
       return;
     }
     if (!labsStore.labs[labId]) {

--- a/packages/front-end/src/app/pages/labs/[labId]/seqera-run/[seqeraRunId].vue
+++ b/packages/front-end/src/app/pages/labs/[labId]/seqera-run/[seqeraRunId].vue
@@ -36,6 +36,8 @@
   ]);
   const seqeraRun = computed(() => runStore.seqeraRuns[labId]?.[seqeraRunId] || null);
 
+  useInitialPendingRequests('loadSeqeraRun', 'loadRunReports');
+
   usePageTitle(() => (seqeraRun.value?.runName ? seqeraRun.value.runName : 'Seqera run'));
 
   const createdDateTime = computed(() => formatDateTime(seqeraRun.value?.dateCreated));
@@ -90,7 +92,12 @@
   }
 
   async function fetchSeqeraRun(): Promise<void> {
-    await runStore.loadSingleSeqeraRun(labId, seqeraRunId);
+    useUiStore().setRequestPending('loadSeqeraRun');
+    try {
+      await runStore.loadSingleSeqeraRun(labId, seqeraRunId);
+    } finally {
+      useUiStore().setRequestComplete('loadSeqeraRun');
+    }
   }
 
   function handleTabChange(newIndex: number) {

--- a/packages/front-end/src/app/stores/ui.ts
+++ b/packages/front-end/src/app/stores/ui.ts
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia';
 
-type PendingRequest =
+export type PendingRequest =
   | 'signIn'
   | 'forgotPassword'
   | 'resetPassword'


### PR DESCRIPTION
## fix: show loading skeletons on first paint instead of flashing content

## Type of Change*
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
- Stop the load-status flash where views briefly render content, then a skeleton, then content again. Vue paints once before `onMounted`/`onBeforeMount`, so loading flags that started `false` (or empty `pendingRequests`) showed the empty/stale UI first.
- Mark initial fetches as pending during setup via `useInitialPendingRequests`, and start local load flags as `true`, so the first paint is already the skeleton. Covers lab/org settings, lists, dashboard, data collections, run pages, and related loaders.
- Clip `EGCollapsibleSection` header hover to the card radius so the hover fill no longer squares off the corners (the small hover bug on the same Lab details container).

## Testing*
- Lab Settings: refresh / navigate to the tab — Lab details card should not flash empty form → skeleton → form. Hover the **Lab details** header; corners should stay rounded with no layout jump.
- Retest `EGCollapsibleSection` on Create lab and the other settings cards (Integrations, AI Failure Analysis, HealthOmics VPC Networking, Run Notifications).
- Spot-check the same first-paint flash on: Labs list, Organizations list, lab dashboard, Data Collections, org Settings, a run detail page, and File Manager.
- Confirm Safari and Chrome (original report). Loading skeletons should appear immediately, then content, with no intermediate populated flash.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [x] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.