### PR TITLE
fix: keep sidebar collapse button visible while page scrolls

### DIFF
--- a/packages/front-end/src/app/components/EGSidebarNav.vue
+++ b/packages/front-end/src/app/components/EGSidebarNav.vue
@@ -237,7 +237,7 @@
     top: -1.5rem;
     bottom: 0;
     width: var(--sidebar-width);
-    padding: 2rem 2rem 1rem;
+    padding: 2rem 2rem 5rem;
     min-height: calc(100vh - var(--header-height));
     border-right: 1px solid #e5e5e5;
     border-top: 1px solid #e5e5e5;
@@ -249,12 +249,33 @@
     &--collapsed {
       left: calc(-1 * var(--sidebar-width-collapsed) - var(--sidebar-content-gap));
       width: var(--sidebar-width-collapsed);
-      padding: 1rem 0.5rem;
+      padding: 1rem 0.5rem 5rem;
     }
   }
 
+  // Stay pinned to the viewport so Collapse remains visible on long pages.
+  // Horizontal padding matches the sidebar so the control lines up with nav items.
   .sidebar-nav__footer {
-    margin-top: auto;
+    position: fixed;
+    left: 0;
+    bottom: 0;
+    z-index: 20;
+    box-sizing: border-box;
+    width: var(--sidebar-width);
+    padding: 0 2rem 1rem;
+    background-color: #ffffff;
+    transition:
+      width 0.2s ease,
+      padding 0.2s ease;
+  }
+
+  .sidebar-nav--collapsed .sidebar-nav__footer {
+    width: var(--sidebar-width-collapsed);
+    padding: 0 0.5rem 1rem;
+  }
+
+  .sidebar-nav--dark .sidebar-nav__footer {
+    background-color: #1b1a29;
   }
 
   // Dark treatment used by the org-admin area to read as a distinct place from the light lab workspace.


### PR DESCRIPTION
## fix: keep sidebar collapse button visible while page scrolls

## Type of Change*
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
- Keep the sidebar scrolling with the page
- Pin only the Collapse / Expand control to the bottom of the viewport so it stays visible on long pages (dashboard, runs, settings)

## Testing*
- Open a page with a long scroll (dashboard, many runs, or settings) and confirm the collapse button stays visible at the bottom of the viewport without scrolling to the end of the page
- Confirm the rest of the sidebar (nav items) still scrolls with the page and is not fixed
- Confirm collapsing and expanding the sidebar still works, and the button stays aligned in both states

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [x] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.