### PR TITLE
fix(lab-settings): fix Save Changes failing when LLM provider set to None

### DIFF
--- a/packages/front-end/src/app/components/EGFormLabDetails.vue
+++ b/packages/front-end/src/app/components/EGFormLabDetails.vue
@@ -128,11 +128,14 @@
   const isEditingGitHubAccessToken = ref(false);
 
   // BYOK provider dropdown options + per-provider hints/placeholders for the
-  // Model ID input. The leading `null` option lets users reset back to "no
+  // Model ID input. The leading `''` option lets users reset back to "no
   // provider" — USelect's placeholder is only shown when the value is empty,
-  // so without an explicit reset option the dropdown becomes one-way.
+  // so without an explicit reset option the dropdown becomes one-way. `null`
+  // doesn't work here: USelect renders a native <select>, whose <option value>
+  // can only carry strings, so a `null` value falls back to the option's label
+  // text instead — which then fails the LlmProvider enum on save.
   const llmProviderOptions = [
-    { value: null, label: 'None — disable AI analysis' },
+    { value: '', label: 'None — disable AI analysis' },
     { value: 'bedrock', label: 'Amazon Bedrock (uses platform IAM, no key required)' },
     { value: 'openai', label: 'OpenAI' },
     { value: 'anthropic', label: 'Anthropic' },
@@ -637,7 +640,7 @@
   async function handleConfirmSaveRetentionPolicyChange() {
     useUiStore().setRequestPending('updateLab');
     try {
-      const parseResult = UpdateLaboratorySchema.safeParse(state.value);
+      const parseResult = UpdateLaboratorySchema.safeParse(withNormalizedLlmFields(state.value));
       if (!parseResult.success) {
         const message = 'Update lab failed to parse lab details';
         console.error(`${message}; parseResult: `, parseResult);


### PR DESCRIPTION
## Summary
Fixes a bug where, on the Edit Lab / Lab Settings page, selecting **"None — disable AI analysis"** for the HealthOmics or Seqera **LLM Provider** dropdown and clicking **Save Changes** threw a client-side Zod validation error (`Update lab failed to parse lab details`) and an "unknown error" toast.

## Root cause
The "None" dropdown option used `value: null`. `USelect` (`@nuxt/ui` 2.18.4) renders a native `<select>`/`<option>` under the hood, and a native `<option value>` attribute can only carry strings — so selecting a `null`-valued option fell back to emitting the option's **label text** (`"None — disable AI analysis"`) as the model value instead of `null`. That literal string then failed the `HealthOmicsLlmProvider` / `SeqeraLlmProvider` Zod enum (`z.enum(['bedrock', 'openai', 'anthropic']).optional()`) on save.

Confirmed via a live Zod repro and the actual console error, not just code reading.

## Fix
- `llmProviderOptions`: use `value: ''` instead of `value: null` for the "None" entry. Native `<option value="">` binds correctly. Same label, same three real provider choices, same reset behavior — only the internal sentinel changed.
- `withNormalizedLlmFields()` already treats `''` as "unset" and converts it to `undefined` before validating, matching the schema's `.optional()` — no schema changes needed.
- `handleConfirmSaveRetentionPolicyChange()` (the save path used when `RunRetentionMonths` also changed) was validating raw `state.value` without that normalization. Fixed it to call `withNormalizedLlmFields()`, matching `handleUpdateLabDetails()`, so it doesn't hit the same class of failure via the retention-policy confirmation dialog.

## Testing
No existing unit tests cover this component's submit handlers, so this was verified manually:
1. Edit Lab → set HealthOmics LLM Provider to "None — disable AI analysis" → Save Changes → succeeds, no console error.
2. Same for Seqera LLM Provider.
3. Change LLM Provider to "None" **and** the retention months in the same edit → confirm the retention-policy dialog → Save Changes → succeeds.

`pnpm lint` and `pnpm test` pass in `packages/front-end`.

