### PR TITLE
fix: align lab settings S3 bucket options with org admin catalog

### DIFF
--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/process-update-laboratory-run.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/process-update-laboratory-run.lambda.ts
@@ -261,11 +261,32 @@ function hasProgressChanged(existingRun: LaboratoryRun, progress: OmicsTaskProgr
   );
 }
 
-/** Merge existing run with a progress snapshot for persistence. */
-function buildProgressUpdate(existingRun: LaboratoryRun, progress: OmicsTaskProgress | undefined): LaboratoryRun {
+const LABORATORY_RUN_PROGRESS_ATTRIBUTES = [
+  'ProgressPercent',
+  'TasksTotal',
+  'TasksCompleted',
+  'TasksRunning',
+  'TasksFailed',
+] as const;
+
+/** Merge existing run with a progress snapshot for persistence; strip progress attrs when terminal. */
+function buildProgressUpdate(
+  existingRun: LaboratoryRun,
+  progress: OmicsTaskProgress | undefined,
+  clearProgressOnTerminal: boolean,
+): { update: LaboratoryRun; remove: string[] } {
+  if (clearProgressOnTerminal) {
+    return {
+      update: { ...existingRun },
+      remove: [...LABORATORY_RUN_PROGRESS_ATTRIBUTES],
+    };
+  }
   return {
-    ...existingRun,
-    ...progressFieldsFromSnapshot(progress),
+    update: {
+      ...existingRun,
+      ...progressFieldsFromSnapshot(progress),
+    },
+    remove: [],
   };
 }
 
@@ -455,7 +476,7 @@ export async function processStatusCheckEvent(operation: SnsProcessingOperation,
       // No status change, but duration and/or task progress need persisting.
       // Progress can change continuously while Status stays RUNNING.
       const now = new Date();
-      const progressUpdate = buildProgressUpdate(existingRun, snapshot.progress);
+      const { update: progressUpdate } = buildProgressUpdate(existingRun, snapshot.progress, false);
       laboratoryRun = await laboratoryRunService.update({
         ...progressUpdate,
         ...(snapshot.durationSeconds != null && existingRun.RunDurationSeconds == null

--- a/packages/back-end/src/app/utils/laboratory-s3-access-utils.ts
+++ b/packages/back-end/src/app/utils/laboratory-s3-access-utils.ts
@@ -71,17 +71,11 @@ export function grantedBucketNamesForLaboratory(
   accessRows: LaboratoryS3Access[],
   catalog: S3BucketCatalogEntry[],
 ): string[] {
+  const catalogNames = new Set(catalog.map((entry) => entry.name));
   const defaultOn = laboratory.EnableNewBucketsByDefault === true;
   if (!defaultOn) {
     const allowed = allowBucketNames(accessRows);
-    // Unmigrated labs: surface the configured default so the UI matches assert fallback.
-    if (allowed.size === 0 && accessRows.length === 0) {
-      const configured = laboratory.S3Bucket?.trim();
-      if (configured) {
-        allowed.add(configured);
-      }
-    }
-    return [...allowed].sort();
+    return [...allowed].filter((name) => catalogNames.has(name)).sort();
   }
   const denied = denyBucketNames(accessRows);
   return catalog

--- a/packages/back-end/test/app/controllers/easy-genomics/laboratory/run/process-update-laboratory-run.lambda.test.ts
+++ b/packages/back-end/test/app/controllers/easy-genomics/laboratory/run/process-update-laboratory-run.lambda.test.ts
@@ -36,6 +36,8 @@ import {
 } from '../../../../../../src/app/controllers/easy-genomics/laboratory/run/process-update-laboratory-run.lambda';
 
 describe('process-update-laboratory-run.lambda', () => {
+  const terminalProgressRemoval = ['ProgressPercent', 'TasksTotal', 'TasksCompleted', 'TasksRunning', 'TasksFailed'];
+
   let mockLabService: jest.MockedClass<typeof LaboratoryService>;
   let mockRunService: jest.MockedClass<typeof LaboratoryRunService>;
   let mockSsmService: jest.MockedClass<typeof SsmService>;
@@ -563,6 +565,7 @@ describe('process-update-laboratory-run.lambda', () => {
         FailureReason: 'OUT_OF_MEMORY_ERROR',
         FailureStatusMessage: 'Task nf-core/rnaseq:FASTQC ran out of memory — see CloudWatch',
       }),
+      terminalProgressRemoval,
     );
   });
 
@@ -606,6 +609,7 @@ describe('process-update-laboratory-run.lambda', () => {
         FailureReason: 'Sample sheet parsing failed',
         FailureErrorReport: 'Caused by:\n  Missing required column "sample" in samplesheet.csv',
       }),
+      terminalProgressRemoval,
     );
   });
 
@@ -772,6 +776,7 @@ describe('process-update-laboratory-run.lambda', () => {
       expect.objectContaining({
         Status: 'SUCCEEDED',
       }),
+      terminalProgressRemoval,
     );
     expect(mockUpdateRun).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/back-end/test/app/controllers/easy-genomics/laboratory/s3-access/list-granted-buckets.lambda.test.ts
+++ b/packages/back-end/test/app/controllers/easy-genomics/laboratory/s3-access/list-granted-buckets.lambda.test.ts
@@ -122,4 +122,18 @@ describe('list-granted-buckets.lambda', () => {
     expect(result.statusCode).toBe(200);
     expect(JSON.parse(result.body)).toEqual({ buckets: ['bucket-b'] });
   });
+
+  it('does not return a legacy configured default when it is off-catalog and there are zero access rows', async () => {
+    mockLabService.prototype.queryByLaboratoryId = jest.fn().mockResolvedValue({
+      OrganizationId: ORG_ID,
+      LaboratoryId: LAB_ID,
+      EnableNewBucketsByDefault: false,
+      S3Bucket: 'stale-bucket',
+    });
+    (mockAccessService.prototype.listByLaboratoryId as jest.Mock).mockResolvedValue([]);
+
+    const result = await handler(createEvent(LAB_ID), createContext(), () => {});
+    expect(result.statusCode).toBe(200);
+    expect(JSON.parse(result.body)).toEqual({ buckets: [] });
+  });
 });

--- a/packages/back-end/test/app/utils/laboratory-s3-access-utils.test.ts
+++ b/packages/back-end/test/app/utils/laboratory-s3-access-utils.test.ts
@@ -89,8 +89,16 @@ describe('laboratory-s3-access-utils', () => {
       expect(grantedBucketNamesForLaboratory(labStrict, [allowRow('bucket-b')], catalog)).toEqual(['bucket-b']);
     });
 
-    it('strict mode with zero rows includes configured S3Bucket', () => {
-      expect(grantedBucketNamesForLaboratory(labStrict, [], catalog)).toEqual(['bucket-a']);
+    it('strict mode with zero rows returns empty list (configured default handled by warning UX)', () => {
+      expect(grantedBucketNamesForLaboratory(labStrict, [], catalog)).toEqual([]);
+    });
+
+    it('strict mode excludes ALLOW buckets that are no longer in the catalog', () => {
+      expect(grantedBucketNamesForLaboratory(labStrict, [allowRow('stale-bucket')], catalog)).toEqual([]);
+    });
+
+    it('strict mode includes ALLOW buckets that remain in the catalog', () => {
+      expect(grantedBucketNamesForLaboratory(labStrict, [allowRow('bucket-a')], catalog)).toEqual(['bucket-a']);
     });
 
     it('default-on excludes DENY buckets', () => {

--- a/packages/front-end/src/app/components/EGFormLabDetails.vue
+++ b/packages/front-end/src/app/components/EGFormLabDetails.vue
@@ -34,6 +34,7 @@
     DEFAULT_RUN_DETAIL_PROGRESS_POLL_INTERVAL_SECONDS,
     DEFAULT_RUN_LIST_STATUS_POLL_INTERVAL_SECONDS,
   } from '@easy-genomics/shared-lib/src/app/utils/laboratory-run-progress-polling';
+  import { fetchLabS3BucketOptions } from '@FE/utils/lab-s3-bucket-options';
 
   const props = withDefaults(
     defineProps<{
@@ -452,12 +453,12 @@
   async function getS3Buckets() {
     try {
       isLoadingBuckets.value = true;
-      if (formMode.value !== LabDetailsFormModeEnum.enum.Create && labId) {
-        const granted = await $api.s3Access.listGrantedBuckets(labId);
-        s3Directories.value = granted.buckets;
-      } else {
-        s3Directories.value = await $api.infra.s3Buckets().then((res) => res.map((bucket) => bucket.Name));
-      }
+      s3Directories.value = await fetchLabS3BucketOptions({
+        isCreateMode: formMode.value === LabDetailsFormModeEnum.enum.Create,
+        labId,
+        orgId: useUserStore().currentOrgId,
+        api: $api.s3Access,
+      });
     } catch (error) {
       useToastStore().error('Failed to retrieve S3 buckets');
     } finally {

--- a/packages/front-end/src/app/utils/lab-s3-bucket-options.ts
+++ b/packages/front-end/src/app/utils/lab-s3-bucket-options.ts
@@ -1,0 +1,27 @@
+export interface LabS3BucketOptionsApi {
+  listGrantedBuckets(laboratoryId: string): Promise<{ buckets: string[] }>;
+  listCatalog(organizationId: string): Promise<{ buckets: { name: string }[] }>;
+}
+
+/**
+ * Loads S3 bucket names for the lab settings dropdown.
+ * Create mode uses the org-wide data-tagged catalog; edit mode uses effective granted buckets for the lab.
+ */
+export async function fetchLabS3BucketOptions(params: {
+  isCreateMode: boolean;
+  labId?: string;
+  orgId?: string | null;
+  api: LabS3BucketOptionsApi;
+}): Promise<string[]> {
+  if (!params.isCreateMode && params.labId) {
+    const granted = await params.api.listGrantedBuckets(params.labId);
+    return granted.buckets;
+  }
+
+  if (!params.orgId) {
+    return [];
+  }
+
+  const catalog = await params.api.listCatalog(params.orgId);
+  return catalog.buckets.map((bucket) => bucket.name);
+}

--- a/packages/front-end/test/app/utils/lab-s3-bucket-options.test.ts
+++ b/packages/front-end/test/app/utils/lab-s3-bucket-options.test.ts
@@ -1,0 +1,56 @@
+import { fetchLabS3BucketOptions } from '../../../src/app/utils/lab-s3-bucket-options';
+
+describe('fetchLabS3BucketOptions', () => {
+  const api = {
+    listGrantedBuckets: jest.fn(),
+    listCatalog: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('create mode loads bucket names from the org S3 access catalog', async () => {
+    api.listCatalog.mockResolvedValue({ buckets: [{ name: 'bucket-a' }, { name: 'bucket-b' }] });
+
+    await expect(
+      fetchLabS3BucketOptions({
+        isCreateMode: true,
+        orgId: 'org-1',
+        api,
+      }),
+    ).resolves.toEqual(['bucket-a', 'bucket-b']);
+
+    expect(api.listCatalog).toHaveBeenCalledWith('org-1');
+    expect(api.listGrantedBuckets).not.toHaveBeenCalled();
+  });
+
+  it('edit mode loads effective granted buckets for the lab', async () => {
+    api.listGrantedBuckets.mockResolvedValue({ buckets: ['bucket-a'] });
+
+    await expect(
+      fetchLabS3BucketOptions({
+        isCreateMode: false,
+        labId: 'lab-1',
+        orgId: 'org-1',
+        api,
+      }),
+    ).resolves.toEqual(['bucket-a']);
+
+    expect(api.listGrantedBuckets).toHaveBeenCalledWith('lab-1');
+    expect(api.listCatalog).not.toHaveBeenCalled();
+  });
+
+  it('create mode returns an empty list when orgId is missing', async () => {
+    await expect(
+      fetchLabS3BucketOptions({
+        isCreateMode: true,
+        orgId: null,
+        api,
+      }),
+    ).resolves.toEqual([]);
+
+    expect(api.listCatalog).not.toHaveBeenCalled();
+    expect(api.listGrantedBuckets).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Title*
Align lab settings S3 bucket options with org admin catalog

## Type of Change*
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
The organization admin S3 access panel and the lab settings default-bucket dropdown were showing inconsistent bucket lists because they used different data sources.

**S3 bucket alignment**
- Lab settings **create mode** now loads the org S3 access catalog (`listCatalog`) instead of the legacy `/list-buckets` endpoint.
- Lab settings **edit mode** continues to use `listGrantedBuckets`, but the backend now returns only catalog-backed buckets in strict mode.
- Removed the UI-facing legacy fallback that surfaced `Laboratory.S3Bucket` when a lab had zero access rows; stale defaults are handled by the existing warning UX instead of appearing as selectable options.
- Added `fetchLabS3BucketOptions` helper to centralize the create vs edit loading logic.

**Run status-check fix (bundled)**
- Fixed a TypeScript mismatch in `buildProgressUpdate()` where terminal status transitions expected `{ update, remove }` but the helper still returned a plain `LaboratoryRun`.
- Terminal transitions now strip transient progress attributes (`ProgressPercent`, task counts) via `updateWithAttributeRemoval`.

## Testing*
- [x] `packages/back-end/test/app/utils/laboratory-s3-access-utils.test.ts`
- [x] `packages/back-end/test/app/controllers/easy-genomics/laboratory/s3-access/list-granted-buckets.lambda.test.ts`
- [x] `packages/front-end/test/app/utils/lab-s3-bucket-options.test.ts`
- [x] `packages/back-end/test/app/controllers/easy-genomics/laboratory/run/process-update-laboratory-run.lambda.test.ts` (updated terminal transition assertions)

Manual verification recommended:
- [ ] Org admin **S3 access** tab bucket list matches lab settings **Default S3 bucket directory** dropdown for the same lab
- [ ] Creating a new lab shows the same catalog buckets as org admin
- [ ] A lab with a revoked/stale default bucket shows the warning message and blocks save until a valid bucket is selected

## Impact
- **Behaviour:** Lab settings S3 dropdown options now match the org admin S3 access model. Legacy unmigrated labs with a configured default but no access rows will see an empty dropdown plus the existing stale-bucket warning, rather than the old default appearing as selectable.
- **Runtime auth:** Unchanged — `isS3BucketAccessAllowed` / `assertLaboratoryHasS3BucketAccess` still allow the configured default for unmigrated labs at the API layer.
- **Terminal runs:** Progress fields are removed from DynamoDB when a run reaches a terminal status.
- **No new dependencies.**

## Additional Information
The legacy `/list-buckets` endpoint and `infra.s3Buckets()` remain in the codebase but are no longer used by lab settings. They can be deprecated in a follow-up if unused elsewhere.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [ ] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.