### PR TITLE
fix: show specific error and require Model ID on Lab Settings save

### DIFF
--- a/packages/front-end/src/app/components/EGFormLabDetails.vue
+++ b/packages/front-end/src/app/components/EGFormLabDetails.vue
@@ -12,6 +12,7 @@
     RunRetentionMonthsSchema,
     NetworkingModeSchema,
     VpcConfigurationNameSchema,
+    LlmModelIdSchema,
     LabDetailsFormModeEnum,
     LabDetailsFormMode,
   } from '@FE/types/labs';
@@ -21,6 +22,7 @@
   import { ButtonSizeEnum, ButtonVariantEnum } from '@FE/types/buttons';
   import { useToastStore, useUiStore } from '@FE/stores';
   import { maybeAddFieldValidationErrors } from '@FE/utils/form-utils';
+  import { extractApiErrorMessage, formatValidationIssues } from '@FE/utils/api-utils';
   import {
     CreateLaboratory,
     CreateLaboratorySchema,
@@ -128,12 +130,12 @@
   const isEditingGitHubAccessToken = ref(false);
 
   // BYOK provider dropdown options + per-provider hints/placeholders for the
-  // Model ID input. The leading `''` option lets users reset back to "no
-  // provider" — USelect's placeholder is only shown when the value is empty,
-  // so without an explicit reset option the dropdown becomes one-way. `null`
-  // doesn't work here: USelect renders a native <select>, whose <option value>
-  // can only carry strings, so a `null` value falls back to the option's label
-  // text instead — which then fails the LlmProvider enum on save.
+  // Model ID input. The leading option lets users reset back to "no provider".
+  // Its value is '' rather than null: USelect renders a native <select>, whose
+  // <option value> can only carry strings, so a null-valued option falls back
+  // to the option's label text instead — which then fails the LlmProvider enum
+  // on save. '' also collides with the empty-string value USelect's own
+  // :placeholder prop injects, so :placeholder is skipped on the USelects below.
   const llmProviderOptions = [
     { value: '', label: 'None — disable AI analysis' },
     { value: 'bedrock', label: 'Amazon Bedrock (uses platform IAM, no key required)' },
@@ -337,6 +339,34 @@
         return '';
     }
   }
+  // Maps CreateLaboratorySchema/UpdateLaboratorySchema field names to the section and label
+  // shown for them in this form, so a safeParse failure can name which section to fix.
+  const LAB_DETAILS_FIELD_LABELS: Record<string, string> = {
+    Name: 'Lab details – Name',
+    Description: 'Lab details – Description',
+    S3Bucket: 'Lab details – Default S3 bucket directory',
+    Status: 'Lab details – Status',
+    RunRetentionMonths: 'Lab details – Run retention',
+    RunListStatusPollIntervalSeconds: 'Lab details – Run list poll interval',
+    RunDetailProgressPollIntervalSeconds: 'Lab details – Run detail poll interval',
+    NextFlowTowerEnabled: 'Integrations – Seqera enabled',
+    NextFlowTowerApiBaseUrl: 'Integrations – Seqera API base URL',
+    NextFlowTowerWorkspaceId: 'Integrations – Seqera workspace ID',
+    NextFlowTowerAccessToken: 'Integrations – Seqera access token',
+    GitHubAccessToken: 'Integrations – GitHub access token',
+    AwsHealthOmicsEnabled: 'Integrations – HealthOmics enabled',
+    AwsHealthOmicsNetworkingMode: 'HealthOmics VPC Networking – Networking mode',
+    AwsHealthOmicsVpcConfigurationName: 'HealthOmics VPC Networking – VPC configuration name',
+    HealthOmicsLogEnrichmentEnabled: 'AI Failure Analysis (HealthOmics) – Log enrichment enabled',
+    HealthOmicsLlmProvider: 'AI Failure Analysis (HealthOmics) – LLM provider',
+    HealthOmicsLlmModelId: 'AI Failure Analysis (HealthOmics) – Model ID',
+    HealthOmicsLlmApiKey: 'AI Failure Analysis (HealthOmics) – API key',
+    SeqeraLlmProvider: 'AI Failure Analysis (Seqera) – LLM provider',
+    SeqeraLlmModelId: 'AI Failure Analysis (Seqera) – Model ID',
+    SeqeraLlmApiKey: 'AI Failure Analysis (Seqera) – API key',
+    NotificationsEnabled: 'Run Notifications – Enabled',
+  };
+
   /**
    * USelect's "reset to none" option uses `null` as the value, but the backend
    * Zod schemas only accept `string | undefined`. Normalize before submitting
@@ -609,7 +639,9 @@
       } else if (error.message === `Request error: ${ERROR_CODES['EG-308']}`) {
         useToastStore().error('Invalid Workspace ID or Personal Access Token. Please try again.');
       } else {
-        useToastStore().error('An unknown error occurred. Please refresh the page and try again.');
+        useToastStore().error(
+          extractApiErrorMessage(error) ?? 'An unknown error occurred. Please refresh the page and try again.',
+        );
       }
     } finally {
       useUiStore().setRequestComplete('createLab');
@@ -642,9 +674,10 @@
     try {
       const parseResult = UpdateLaboratorySchema.safeParse(withNormalizedLlmFields(state.value));
       if (!parseResult.success) {
-        const message = 'Update lab failed to parse lab details';
-        console.error(`${message}; parseResult: `, parseResult);
-        throw new Error(message);
+        console.error('Update lab failed to parse lab details; parseResult: ', parseResult);
+        throw new Error(
+          `Couldn't save — check: ${formatValidationIssues(parseResult.error.issues, LAB_DETAILS_FIELD_LABELS)}`,
+        );
       }
 
       const lab = parseResult.data as UpdateLaboratory;
@@ -682,7 +715,9 @@
       } else if (error.message === `Request error: ${ERROR_CODES['EG-308']}`) {
         useToastStore().error('Invalid Workspace ID or Personal Access Token. Please try again.');
       } else {
-        useToastStore().error('An unknown error occurred. Please refresh the page and try again.');
+        useToastStore().error(
+          extractApiErrorMessage(error) ?? 'An unknown error occurred. Please refresh the page and try again.',
+        );
       }
     } finally {
       useUiStore().setRequestComplete('updateLab');
@@ -701,9 +736,10 @@
 
     const parseResult = CreateLaboratorySchema.safeParse(lab);
     if (!parseResult.success) {
-      const message = 'Create lab failed to parse lab details';
-      console.error(`${message}; parseResult: `, parseResult);
-      throw new Error(message);
+      console.error('Create lab failed to parse lab details; parseResult: ', parseResult);
+      throw new Error(
+        `Couldn't save — check: ${formatValidationIssues(parseResult.error.issues, LAB_DETAILS_FIELD_LABELS)}`,
+      );
     }
 
     const newLab = parseResult.data as CreateLaboratory;
@@ -726,9 +762,10 @@
     const parseResult = UpdateLaboratorySchema.safeParse(withNormalizedLlmFields(state.value));
 
     if (!parseResult.success) {
-      const message = 'Update lab failed to parse lab details';
-      console.error(`${message}; parseResult: `, parseResult);
-      throw new Error(message);
+      console.error('Update lab failed to parse lab details; parseResult: ', parseResult);
+      throw new Error(
+        `Couldn't save — check: ${formatValidationIssues(parseResult.error.issues, LAB_DETAILS_FIELD_LABELS)}`,
+      );
     }
 
     const lab: UpdateLaboratory = parseResult.data;
@@ -806,6 +843,14 @@
         'AwsHealthOmicsVpcConfigurationName',
         state.AwsHealthOmicsVpcConfigurationName,
       );
+    }
+
+    // Model ID is only meaningful once a provider is picked for that integration.
+    if (state.HealthOmicsLlmProvider) {
+      maybeAddFieldValidationErrors(errors, LlmModelIdSchema, 'HealthOmicsLlmModelId', state.HealthOmicsLlmModelId);
+    }
+    if (state.SeqeraLlmProvider) {
+      maybeAddFieldValidationErrors(errors, LlmModelIdSchema, 'SeqeraLlmModelId', state.SeqeraLlmModelId);
     }
 
     if (notifyOnLabRunsEnabled.value && additionalEmailsError.value) {
@@ -1261,7 +1306,6 @@
               :options="llmProviderOptions"
               value-attribute="value"
               option-attribute="label"
-              placeholder="None — disable AI analysis for HealthOmics"
               :disabled="!isEditing || isSubmittingFormData"
             />
           </EGFormGroup>
@@ -1271,6 +1315,7 @@
             label="Model ID"
             name="HealthOmicsLlmModelId"
             eager-validation
+            required
             :hint="modelIdHintFor(state.HealthOmicsLlmProvider)"
           >
             <EGInput
@@ -1333,7 +1378,6 @@
               :options="llmProviderOptions"
               value-attribute="value"
               option-attribute="label"
-              placeholder="None — disable AI analysis for Seqera"
               :disabled="!isEditing || isSubmittingFormData"
             />
           </EGFormGroup>
@@ -1343,6 +1387,7 @@
             label="Model ID"
             name="SeqeraLlmModelId"
             eager-validation
+            required
             :hint="modelIdHintFor(state.SeqeraLlmProvider)"
           >
             <EGInput

--- a/packages/front-end/src/app/types/labs.ts
+++ b/packages/front-end/src/app/types/labs.ts
@@ -46,7 +46,11 @@ const RunDetailProgressPollIntervalSecondsSchema = z
   .max(300, 'Run detail polling interval must be between 10 and 300 seconds');
 
 const LlmProviderSchema = z.enum(['bedrock', 'openai', 'anthropic']);
-const LlmModelIdSchema = z.string().trim().max(256, 'Model ID must be no more than 256 characters');
+const LlmModelIdSchema = z
+  .string()
+  .trim()
+  .min(1, 'Model ID is required')
+  .max(256, 'Model ID must be no more than 256 characters');
 const LlmApiKeySchema = z.string().trim().min(1, 'API key cannot be empty');
 
 const NetworkingModeSchema = z.enum(['RESTRICTED', 'VPC']);

--- a/packages/front-end/src/app/utils/api-utils.ts
+++ b/packages/front-end/src/app/utils/api-utils.ts
@@ -1,4 +1,35 @@
-import { ZodSchema } from 'zod';
+import { ZodIssue, ZodSchema } from 'zod';
+
+const REQUEST_ERROR_PREFIX = 'Request error: ';
+
+/**
+ * Extracts the underlying API error message from an Error thrown by HttpFactory.performRequest,
+ * which wraps every failure (including the backend's specific `Error` field) as `Request error: <message>`.
+ * Returns undefined if the error doesn't carry a usable message, so callers can fall back to a generic string.
+ */
+export function extractApiErrorMessage(error: unknown): string | undefined {
+  const message = error instanceof Error ? error.message : undefined;
+  if (!message) return undefined;
+
+  const stripped = message.startsWith(REQUEST_ERROR_PREFIX) ? message.slice(REQUEST_ERROR_PREFIX.length) : message;
+  return stripped.trim().length > 0 ? stripped : undefined;
+}
+
+/**
+ * Turns Zod safeParse issues into a single human-readable string naming each failing field,
+ * so a client-side validation failure can tell the user which field(s) to fix instead of a
+ * generic "failed to validate" message. `fieldLabels` maps a schema field name to a UI-facing
+ * label (e.g. "AI Failure Analysis – Model ID"); fields not in the map fall back to their raw name.
+ */
+export function formatValidationIssues(issues: ZodIssue[], fieldLabels: Record<string, string> = {}): string {
+  return issues
+    .map((issue) => {
+      const field = issue.path.join('.');
+      const label = fieldLabels[field] ?? field;
+      return `${label}: ${issue.message}`;
+    })
+    .join('; ');
+}
 
 export function validateApiResponse<T>(schema: ZodSchema<T>, data: any) {
   const validation = schema.safeParse(data);


### PR DESCRIPTION
## Title*
Show specific error and require Model ID on Lab Settings save

## Type of Change*
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Editing Lab Settings across multiple sections (e.g. VPC + Run Notifications) and hitting an error in one of them showed a generic "An unknown error occurred. Please refresh the page and try again." toast, with no hint which field was wrong. A single-section error (e.g. Notification recipients) already showed a specific message, since that path has its own try/catch.

Changes:
- `extractApiErrorMessage` (`api-utils.ts`): surfaces the backend's actual error message instead of the hardcoded generic fallback, for any error `$api.labs.update(...)` doesn't already special-case (EG-304/EG-308).
- `formatValidationIssues` + `LAB_DETAILS_FIELD_LABELS` (`api-utils.ts` / `EGFormLabDetails.vue`): when client-side Zod validation fails before any network call, the toast now names every failing field and its section (e.g. `AI Failure Analysis (HealthOmics) – LLM provider: ...`) instead of a single generic "failed to parse lab details" message.
- Model ID is now required once an LLM provider is picked (`LlmModelIdSchema` in `labs.ts` gained `.min(1)`), with an inline error and a disabled Save button — previously there was no validation on it at all.
- `handleConfirmSaveRetentionPolicyChange` was missing `withNormalizedLlmFields`, letting a `null` LLM provider reach the Zod schema unnormalized and fail validation on that save path specifically.
- The LLM provider "None" option collided with `USelect`'s auto-injected placeholder option (both resolved to the same DOM value under a native `<select>`), which could leave Model ID visibly required even after selecting "None". Fixed by using `''` as the sentinel and dropping the now-redundant `:placeholder` prop.

Note: the previous two points overlap with `fix/lab-settings-none-llm-provider-save` (already merged/in review separately) — that branch fixes the same root cause via the `null`→`''` sentinel and the missing normalization call, but keeps the `:placeholder` prop, which doesn't clear the auto-placeholder collision on its own. Expect a merge conflict/duplicate diff to reconcile against that PR.

## Testing*
- `pnpm lint` and `pnpm test` pass in `packages/front-end` (126 tests).
- Manual repro: edited VPC networking to a non-ACTIVE HealthOmics configuration plus a Notifications field in the same save — toast now shows the specific backend message (e.g. `AWS HealthOmics Configuration '...' is not ACTIVE`) instead of the generic fallback.
- Manual repro: selecting an LLM Provider and leaving Model ID blank now shows an inline "Model ID is required" error and disables Save.
- Manual repro: selecting "None" for HealthOmics/Seqera LLM Provider now hides Model ID immediately and saves without error.

## Impact
Front-end only (`packages/front-end`). No schema/API contract changes — validation messages and client-side required-field enforcement only.

## Additional Information
Overlaps with `fix/lab-settings-none-llm-provider-save` on the same two code spots (see Description) — will need reconciling, whichever merges second.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [ ] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.
