### PR TITLE
fix: broken unit test

### DIFF
--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/process-update-laboratory-run.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/process-update-laboratory-run.lambda.ts
@@ -389,38 +389,31 @@ export async function processStatusCheckEvent(operation: SnsProcessingOperation,
           ? calculateExpiresAtEpochSeconds(new Date(terminalAtIso), retentionMonths)
           : undefined;
 
-      const { update: progressUpdate, remove: progressRemove } = buildProgressUpdate(
-        existingRun,
-        snapshot.progress,
-        nextStatusTerminal,
-      );
+      const progressUpdate = buildProgressUpdate(existingRun, snapshot.progress);
 
       // Write status (and terminal metadata) before cost capture. Large Omics runs
       // can spend minutes in ListRunTasks; blocking here left Status stuck at RUNNING
       // until the Lambda timed out and SQS retried forever.
-      laboratoryRun = await laboratoryRunService.updateWithAttributeRemoval(
-        {
-          ...progressUpdate,
-          Status: newStatusNormalized,
-          ...(shouldSetTerminalAt ? { TerminalAt: terminalAtIso } : {}),
-          ...(newExpiresAt !== undefined ? { ExpiresAt: newExpiresAt } : {}),
-          ...(snapshot.durationSeconds != null && existingRun.RunDurationSeconds == null
-            ? { RunDurationSeconds: snapshot.durationSeconds }
-            : {}),
-          ...(newStatusNormalized === 'FAILED' && snapshot.failureReason && existingRun.FailureReason == null
-            ? { FailureReason: snapshot.failureReason }
-            : {}),
-          ...(newStatusNormalized === 'FAILED' && snapshot.statusMessage && existingRun.FailureReason == null
-            ? { FailureStatusMessage: snapshot.statusMessage }
-            : {}),
-          ...(newStatusNormalized === 'FAILED' && snapshot.errorReport && existingRun.FailureReason == null
-            ? { FailureErrorReport: snapshot.errorReport }
-            : {}),
-          ModifiedAt: now.toISOString(),
-          ModifiedBy: 'Status Check',
-        },
-        progressRemove,
-      );
+      laboratoryRun = await laboratoryRunService.update({
+        ...progressUpdate,
+        Status: newStatusNormalized,
+        ...(shouldSetTerminalAt ? { TerminalAt: terminalAtIso } : {}),
+        ...(newExpiresAt !== undefined ? { ExpiresAt: newExpiresAt } : {}),
+        ...(snapshot.durationSeconds != null && existingRun.RunDurationSeconds == null
+          ? { RunDurationSeconds: snapshot.durationSeconds }
+          : {}),
+        ...(newStatusNormalized === 'FAILED' && snapshot.failureReason && existingRun.FailureReason == null
+          ? { FailureReason: snapshot.failureReason }
+          : {}),
+        ...(newStatusNormalized === 'FAILED' && snapshot.statusMessage && existingRun.FailureReason == null
+          ? { FailureStatusMessage: snapshot.statusMessage }
+          : {}),
+        ...(newStatusNormalized === 'FAILED' && snapshot.errorReport && existingRun.FailureReason == null
+          ? { FailureErrorReport: snapshot.errorReport }
+          : {}),
+        ModifiedAt: now.toISOString(),
+        ModifiedBy: 'Status Check',
+      });
       await safePropagateExpiresAt(laboratory, laboratoryRun, newExpiresAt);
       if (newStatusNormalized === 'FAILED' && existingRun.FailureOwner == null) {
         await safePublishForClassification(laboratoryRun);

--- a/packages/back-end/test/app/controllers/easy-genomics/laboratory/run/process-update-laboratory-run.lambda.test.ts
+++ b/packages/back-end/test/app/controllers/easy-genomics/laboratory/run/process-update-laboratory-run.lambda.test.ts
@@ -798,7 +798,6 @@ describe('process-update-laboratory-run.lambda', () => {
       expect.objectContaining({
         Status: 'SUCCEEDED',
       }),
-      expect.any(Array),
     );
     expect(mockUpdateRun).not.toHaveBeenCalledWith(expect.objectContaining({ RunCostOutcome: expect.anything() }));
   });


### PR DESCRIPTION
## Title*
Fix TypeScript compile failure in process-update-laboratory-run status-change path

## Type of Change*
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
The latest merge to `development` broke the back-end CI/CD build. Jest failed to compile `process-update-laboratory-run.lambda.test.ts` with TypeScript errors on the status-change branch:

- `buildProgressUpdate` was called with 3 arguments and destructured as `{ update, remove }`
- The function was simplified in a prior commit to accept 2 arguments and return a plain `LaboratoryRun`

This was a partial merge mismatch: commit `db5d7b22` (persist status before cost capture) reintroduced the old `updateWithAttributeRemoval` call pattern, but the simplified `buildProgressUpdate` signature from `e204fee0` (remove `CurrentProcessName`) was never restored to match.

This PR realigns the status-change branch with the current API:

- Calls `buildProgressUpdate(existingRun, snapshot.progress)` (2 args, returns `LaboratoryRun`)
- Uses `laboratoryRunService.update()` instead of `updateWithAttributeRemoval()`

The cost-capture ordering fix from `db5d7b22` is unchanged — status and terminal metadata are still written before cost capture so large Omics runs don't stay stuck at `RUNNING`.

Also updates a stale test assertion that still expected `updateWithAttributeRemoval`'s second `remove` array argument.

## Testing*
- Ran `npx jest test/app/controllers/easy-genomics/laboratory/run/process-update-laboratory-run.lambda.test.ts` — all 39 tests pass
- Verified the TypeScript errors reported in CI (`TS2339`, `TS2554`) are resolved for this file

## Impact
- Unblocks the back-end build and deploy pipeline
- No behavioural change beyond fixing the compile error; runtime logic matches the simplified progress-update path already used elsewhere in the same handler
- No new dependencies

## Additional Information
Root cause: two commits touched the same code path inconsistently — `e204fee0` simplified `buildProgressUpdate`, and `db5d7b22` partially reverted the call site without updating the function signature.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [ ] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [ ] Code has been commented in particularly hard-to-understand areas.