### PR TITLE
fix: prevent long lab names from stretching the header nav

### DIFF
--- a/packages/front-end/src/app/components/EGHeader.vue
+++ b/packages/front-end/src/app/components/EGHeader.vue
@@ -214,9 +214,9 @@
               inactive-class="text-body"
               active-class="text-primary-dark bg-primary-muted"
               :class="isSubpath(labsPath) ? 'text-primary-dark bg-primary-muted' : ''"
-              class="ULink text-body focus-visible:outline-primary-500 flex h-[30px] max-w-[min(100%,12rem)] items-center justify-center rounded-xl px-3 py-1 font-serif text-sm tracking-normal focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 md:max-w-[min(100%,18rem)] md:px-4"
+              class="ULink text-body focus-visible:outline-primary-500 flex h-[30px] min-w-0 max-w-[12rem] items-center justify-center rounded-xl px-3 py-1 font-serif text-sm tracking-normal focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 md:max-w-[18rem] md:px-4"
             >
-              <span class="truncate">{{ labsNavLabel }}</span>
+              <span class="min-w-0 truncate">{{ labsNavLabel }}</span>
             </ULink>
             <ULink
               v-if="userStore.canManageAnyOrgs()"
@@ -225,13 +225,13 @@
               inactive-class="text-body"
               active-class="text-primary-dark bg-primary-muted"
               :class="isSubpath(orgsPath) ? 'text-primary-dark bg-primary-muted' : ''"
-              class="ULink text-body focus-visible:outline-primary-500 flex h-[30px] items-center justify-center whitespace-nowrap rounded-xl px-3 py-1 font-serif text-sm tracking-normal focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 md:px-4"
+              class="ULink text-body focus-visible:outline-primary-500 flex h-[30px] shrink-0 items-center justify-center whitespace-nowrap rounded-xl px-3 py-1 font-serif text-sm tracking-normal focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 md:px-4"
             >
               Organizations
             </ULink>
           </nav>
 
-          <div ref="accountMenuRoot" class="relative" @focusout="onAccountMenuFocusOut">
+          <div ref="accountMenuRoot" class="relative shrink-0" @focusout="onAccountMenuFocusOut">
             <button
               ref="accountMenuTrigger"
               type="button"


### PR DESCRIPTION
## Title*
Stop long lab names from stretching the global header nav

## Type of Change*
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Long lab names (up to 128 characters) were visually truncated in the Labs nav pill, but the nav itself still laid out to the full untruncated string. That leftover width showed up as a large empty gap between Organizations and the account avatar, so the pills looked shifted left.

The Labs pill used `max-w-[min(100%,18rem)]`. In a shrink-to-fit flex nav that percentage cannot resolve while the nav is measuring itself, so the cap was ignored for layout even though the text showed an ellipsis.

`packages/front-end/src/app/components/EGHeader.vue` now uses a definite `max-w-[12rem] md:max-w-[18rem]`, plus `min-w-0` on the pill and label so truncation actually constrains width. Organizations and the account menu are `shrink-0` so they stay grouped with the pill.

## Testing*
Not yet verified — to verify:

1. Open a lab whose name is at or near 128 characters.
2. Confirm the Labs pill still truncates with an ellipsis.
3. Confirm Labs, Organizations, and the avatar stay grouped on the right with no large empty gap between Organizations and the avatar.
4. Open a lab with a short name and confirm the header looks unchanged.
5. Optionally narrow the viewport and tab to the Labs / Organizations links to confirm they still wrap/shrink without overlapping the avatar and that focus outlines remain visible.

No automated tests were added: this is a CSS layout change, and `EGHeader` has no existing unit tests.

## Impact
Front-end only (`EGHeader.vue`). No backend, schema, infra, dependency, or network changes. Behaviour change is limited to header layout when the current lab name is long enough to truncate; short names should look the same.

## Additional Information
Related to the Labs nav label added in #882. No ticket key was provided with the QA report.

## Checklist*
- [x] No new errors or warnings have been introduced. *(not verified locally)*
- [x] All tests pass successfully and new tests added as necessary. *(no automated tests added — CSS layout-only; EGHeader has no existing unit tests)*
- [x] Documentation has been updated accordingly. *(N/A — no user-facing docs affected)*
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas. *(N/A — no new comments; existing Tailwind classes cover the constraint)*