### PR TITLE
fix: restore terminal progress-clearing call in run status-change branch

### DIFF
--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/process-update-laboratory-run.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/process-update-laboratory-run.lambda.ts
@@ -410,31 +410,38 @@ export async function processStatusCheckEvent(operation: SnsProcessingOperation,
           ? calculateExpiresAtEpochSeconds(new Date(terminalAtIso), retentionMonths)
           : undefined;
 
-      const progressUpdate = buildProgressUpdate(existingRun, snapshot.progress);
+      const { update: progressUpdate, remove: progressRemove } = buildProgressUpdate(
+        existingRun,
+        snapshot.progress,
+        nextStatusTerminal,
+      );
 
       // Write status (and terminal metadata) before cost capture. Large Omics runs
       // can spend minutes in ListRunTasks; blocking here left Status stuck at RUNNING
       // until the Lambda timed out and SQS retried forever.
-      laboratoryRun = await laboratoryRunService.update({
-        ...progressUpdate,
-        Status: newStatusNormalized,
-        ...(shouldSetTerminalAt ? { TerminalAt: terminalAtIso } : {}),
-        ...(newExpiresAt !== undefined ? { ExpiresAt: newExpiresAt } : {}),
-        ...(snapshot.durationSeconds != null && existingRun.RunDurationSeconds == null
-          ? { RunDurationSeconds: snapshot.durationSeconds }
-          : {}),
-        ...(newStatusNormalized === 'FAILED' && snapshot.failureReason && existingRun.FailureReason == null
-          ? { FailureReason: snapshot.failureReason }
-          : {}),
-        ...(newStatusNormalized === 'FAILED' && snapshot.statusMessage && existingRun.FailureReason == null
-          ? { FailureStatusMessage: snapshot.statusMessage }
-          : {}),
-        ...(newStatusNormalized === 'FAILED' && snapshot.errorReport && existingRun.FailureReason == null
-          ? { FailureErrorReport: snapshot.errorReport }
-          : {}),
-        ModifiedAt: now.toISOString(),
-        ModifiedBy: 'Status Check',
-      });
+      laboratoryRun = await laboratoryRunService.updateWithAttributeRemoval(
+        {
+          ...progressUpdate,
+          Status: newStatusNormalized,
+          ...(shouldSetTerminalAt ? { TerminalAt: terminalAtIso } : {}),
+          ...(newExpiresAt !== undefined ? { ExpiresAt: newExpiresAt } : {}),
+          ...(snapshot.durationSeconds != null && existingRun.RunDurationSeconds == null
+            ? { RunDurationSeconds: snapshot.durationSeconds }
+            : {}),
+          ...(newStatusNormalized === 'FAILED' && snapshot.failureReason && existingRun.FailureReason == null
+            ? { FailureReason: snapshot.failureReason }
+            : {}),
+          ...(newStatusNormalized === 'FAILED' && snapshot.statusMessage && existingRun.FailureReason == null
+            ? { FailureStatusMessage: snapshot.statusMessage }
+            : {}),
+          ...(newStatusNormalized === 'FAILED' && snapshot.errorReport && existingRun.FailureReason == null
+            ? { FailureErrorReport: snapshot.errorReport }
+            : {}),
+          ModifiedAt: now.toISOString(),
+          ModifiedBy: 'Status Check',
+        },
+        progressRemove,
+      );
       await safePropagateExpiresAt(laboratory, laboratoryRun, newExpiresAt);
       if (newStatusNormalized === 'FAILED' && existingRun.FailureOwner == null) {
         await safePublishForClassification(laboratoryRun);

--- a/packages/back-end/test/app/controllers/easy-genomics/laboratory/run/process-update-laboratory-run.lambda.test.ts
+++ b/packages/back-end/test/app/controllers/easy-genomics/laboratory/run/process-update-laboratory-run.lambda.test.ts
@@ -803,8 +803,12 @@ describe('process-update-laboratory-run.lambda', () => {
       expect.objectContaining({
         Status: 'SUCCEEDED',
       }),
+      expect.any(Array),
     );
-    expect(mockUpdateRun).not.toHaveBeenCalledWith(expect.objectContaining({ RunCostOutcome: expect.anything() }));
+    expect(mockUpdateRun).not.toHaveBeenCalledWith(
+      expect.objectContaining({ RunCostOutcome: expect.anything() }),
+      expect.any(Array),
+    );
   });
 
   it('backfills RunCostOutcome for already-terminal runs missing cost', async () => {


### PR DESCRIPTION
## Title*
Fix build-blocking type mismatch in `buildProgressUpdate` call at status-change branch

## Type of Change*
- [x] Bug fix

## Description
`development` currently fails `tsc` (and therefore all back-end tests) with:
```
error TS2554: Expected 3 arguments, but got 2.
error TS2345: Argument of type '{...; remove: string[] }' is not assignable to parameter of type 'LaboratoryRun'.
```

**Root cause** — a two-commit interaction in `process-update-laboratory-run.lambda.ts`:

- `b52726e5` ("fix: align lab settings S3 bucket options with org admin catalog") changed `buildProgressUpdate`'s signature from `(existingRun, progress) => LaboratoryRun` to `(existingRun, progress, clearProgressOnTerminal) => { update: LaboratoryRun; remove: string[] }`, and correctly updated the "no status change, but progress needs persisting" branch to the new 3-argument/destructured shape.
- `1ee901ab` ("fix: broken unit test"), landed on a parallel branch off the same parent, reverted the *other* call site — inside the status-**change** branch — back to the old 2-argument/plain-return shape, to satisfy a test that expected `laboratoryRunService.update()` to be called without an attribute-removal array. When both commits were merged into `development`, the status-change branch's call site was left calling the new 3-arg signature incorrectly (2 args, plain-object destructure), which `tsc` rejects.

**Fix** — restored the status-change branch's call site to the current 3-argument signature, mirroring the sibling "no status change" branch that `b52726e5` already fixed correctly:
- Pass `nextStatusTerminal` (the boolean already computed in that scope for "is the new status terminal") as `clearProgressOnTerminal`.
- Destructure `{ update, remove }` and route `remove` into `laboratoryRunService.updateWithAttributeRemoval(...)` (instead of `.update(...)`) so progress attributes (`ProgressPercent`, `TasksTotal`, `TasksCompleted`, `TasksRunning`, `TasksFailed`) are actually stripped from DynamoDB on a terminal status transition, matching the behavior already restored on the other branch.

**Reconciling `1ee901ab`'s original test concern**: that commit reverted the call site because, at the time, `.update()` and `.updateWithAttributeRemoval()` were mocked separately in the test file, so switching the real call from one to the other broke an assertion. That's no longer an issue — the test file's `beforeEach` now explicitly points both mocks at the same `jest.fn()` (`mockUpdateRun = mockUpdateWithAttributeRemoval`, with a comment noting this is intentional), so restoring `updateWithAttributeRemoval(...)` doesn't reintroduce the original failure.

## Testing*
- Reproduced the exact `tsc` failure against the broken code first (`npx jest test/app/controllers/easy-genomics/laboratory/run/process-update-laboratory-run.lambda.test.ts`), confirming TS2554/TS2345 at the reported call site.
- Applied the fix; full back-end test suite (`pnpm test` in `packages/back-end`) now passes: 109 suites / 802 tests.
- The existing test suite already asserts the terminal-transition-clears-progress behavior for several FAILED-transition cases via a `terminalProgressRemoval` constant/`expect.any(Array)` pattern — one test ("swallows cost-capture failures on terminal transition") was still asserting the old (broken) 1-argument call shape after `1ee901ab`'s revert; restored its `expect.any(Array)` second-argument assertion so it actually exercises and verifies the fixed behavior.
- `pnpm lint` passes for `packages/back-end` (only a pre-existing, unrelated import-order warning remains).

## Impact
No behavior change beyond restoring the intended fix from `b52726e5`: on a run status transition to a terminal state, progress attributes are now correctly stripped from the persisted `LaboratoryRun` record, consistent with the non-status-change code path. Unblocks `tsc`/CI on `development`.

## Additional Information
This branch does not touch the Lab Settings / Run Notifications work — it is scoped solely to this type-mismatch fix.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [ ] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.
