### PR TITLE
fix: broken unit test

### DIFF
--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/process-update-laboratory-run.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/run/process-update-laboratory-run.lambda.ts
@@ -410,31 +410,38 @@ export async function processStatusCheckEvent(operation: SnsProcessingOperation,
           ? calculateExpiresAtEpochSeconds(new Date(terminalAtIso), retentionMonths)
           : undefined;
 
-      const progressUpdate = buildProgressUpdate(existingRun, snapshot.progress);
+      const { update: progressUpdate, remove: progressRemove } = buildProgressUpdate(
+        existingRun,
+        snapshot.progress,
+        nextStatusTerminal,
+      );
 
       // Write status (and terminal metadata) before cost capture. Large Omics runs
       // can spend minutes in ListRunTasks; blocking here left Status stuck at RUNNING
       // until the Lambda timed out and SQS retried forever.
-      laboratoryRun = await laboratoryRunService.update({
-        ...progressUpdate,
-        Status: newStatusNormalized,
-        ...(shouldSetTerminalAt ? { TerminalAt: terminalAtIso } : {}),
-        ...(newExpiresAt !== undefined ? { ExpiresAt: newExpiresAt } : {}),
-        ...(snapshot.durationSeconds != null && existingRun.RunDurationSeconds == null
-          ? { RunDurationSeconds: snapshot.durationSeconds }
-          : {}),
-        ...(newStatusNormalized === 'FAILED' && snapshot.failureReason && existingRun.FailureReason == null
-          ? { FailureReason: snapshot.failureReason }
-          : {}),
-        ...(newStatusNormalized === 'FAILED' && snapshot.statusMessage && existingRun.FailureReason == null
-          ? { FailureStatusMessage: snapshot.statusMessage }
-          : {}),
-        ...(newStatusNormalized === 'FAILED' && snapshot.errorReport && existingRun.FailureReason == null
-          ? { FailureErrorReport: snapshot.errorReport }
-          : {}),
-        ModifiedAt: now.toISOString(),
-        ModifiedBy: 'Status Check',
-      });
+      laboratoryRun = await laboratoryRunService.updateWithAttributeRemoval(
+        {
+          ...progressUpdate,
+          Status: newStatusNormalized,
+          ...(shouldSetTerminalAt ? { TerminalAt: terminalAtIso } : {}),
+          ...(newExpiresAt !== undefined ? { ExpiresAt: newExpiresAt } : {}),
+          ...(snapshot.durationSeconds != null && existingRun.RunDurationSeconds == null
+            ? { RunDurationSeconds: snapshot.durationSeconds }
+            : {}),
+          ...(newStatusNormalized === 'FAILED' && snapshot.failureReason && existingRun.FailureReason == null
+            ? { FailureReason: snapshot.failureReason }
+            : {}),
+          ...(newStatusNormalized === 'FAILED' && snapshot.statusMessage && existingRun.FailureReason == null
+            ? { FailureStatusMessage: snapshot.statusMessage }
+            : {}),
+          ...(newStatusNormalized === 'FAILED' && snapshot.errorReport && existingRun.FailureReason == null
+            ? { FailureErrorReport: snapshot.errorReport }
+            : {}),
+          ModifiedAt: now.toISOString(),
+          ModifiedBy: 'Status Check',
+        },
+        progressRemove,
+      );
       await safePropagateExpiresAt(laboratory, laboratoryRun, newExpiresAt);
       if (newStatusNormalized === 'FAILED' && existingRun.FailureOwner == null) {
         await safePublishForClassification(laboratoryRun);

--- a/packages/back-end/test/app/controllers/easy-genomics/laboratory/run/process-update-laboratory-run.lambda.test.ts
+++ b/packages/back-end/test/app/controllers/easy-genomics/laboratory/run/process-update-laboratory-run.lambda.test.ts
@@ -803,6 +803,7 @@ describe('process-update-laboratory-run.lambda', () => {
       expect.objectContaining({
         Status: 'SUCCEEDED',
       }),
+      terminalProgressRemoval,
     );
     expect(mockUpdateRun).not.toHaveBeenCalledWith(expect.objectContaining({ RunCostOutcome: expect.anything() }));
   });


### PR DESCRIPTION
## Title*
Fix status-check progress update call that broke CI typecheck

## Type of Change*
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
CI was failing because `process-update-laboratory-run` did not compile under TypeScript in the Jest suite:

1. `buildProgressUpdate` was called with 2 arguments instead of 3 (`clearProgressOnTerminal` missing).
2. The return value `{ update, remove }` was spread into `laboratoryRunService.update()`, which expects a full `LaboratoryRun`.

On status transitions, the handler now:

- Calls `buildProgressUpdate(existingRun, snapshot.progress, nextStatusTerminal)`
- Destructures `{ update, remove }`
- Persists via `updateWithAttributeRemoval(..., progressRemove)` so progress attributes are cleared when a run becomes terminal (aligned with the non-status-change path and existing test expectations)

Also updates the “swallows cost-capture failures on terminal transition” assertion to expect the progress-attribute removal list.

## Testing*
- Ran `pnpm exec jest test/app/controllers/easy-genomics/laboratory/run/process-update-laboratory-run.lambda.test.ts` — **39/39 passed**
- Confirmed no remaining TypeScript errors in `process-update-laboratory-run.lambda.ts` via `tsc --noEmit`

## Impact
- Restores the back-end build/test pipeline that was failing on this suite’s typecheck.
- Correctly removes progress fields from DynamoDB when a run transitions to a terminal status (behavior the tests already expected).
- No API contract or schema changes.

## Additional Information
- Branch delta vs `development`: 1 commit, 2 files (`process-update-laboratory-run.lambda.ts` + its test).
- This undoes an incomplete earlier edit that switched the status-change path away from `updateWithAttributeRemoval` without updating the `buildProgressUpdate` call site.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [x] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.