### PR TITLE
fix: disable per-user notification prefs when lab-wide emails are off

### DIFF
--- a/packages/front-end/src/app/components/EGFormLabDetails.vue
+++ b/packages/front-end/src/app/components/EGFormLabDetails.vue
@@ -196,6 +196,12 @@
   const uneditedNotificationEventFilter = ref<NotificationEventFilter>('all_terminal');
   const uneditedNotifyOnLabRunsAdditionalEmailsInput = ref('');
 
+  // Per-user preferences have no effect while the lab-wide switch is off, so lock them
+  // instead of letting a user edit settings that won't take effect until it's back on.
+  const runNotificationPreferencesDisabled = computed(
+    () => !isEditing.value || isSubmittingFormData.value || !state.value.NotificationsEnabled,
+  );
+
   // The event filter only has an effect once at least one of the two "email me" toggles is on.
   const showNotificationEventFilter = computed(() => notifyOnOwnRunsEnabled.value || notifyOnLabRunsEnabled.value);
   // 'all_terminal' means both checked; 'failures_only' / 'successes_only' mean only that one.
@@ -1453,7 +1459,7 @@
         <EGFormGroup
           name="NotificationsEnabled"
           eager-validation
-          hint="Turns run notification emails on or off for this lab. Individual users still choose which runs they're emailed about below."
+          hint="Turns off run-completion emails for everyone in this lab and disables the preferences below until this is re-enabled."
         >
           <div class="flex items-center justify-between">
             <label
@@ -1461,7 +1467,7 @@
               :for="`${notificationsToggleLabelId}-input`"
               class="text-sm text-black"
             >
-              Enable run notifications
+              Enable email notifications for this lab
             </label>
             <UToggle
               :id="`${notificationsToggleLabelId}-input`"
@@ -1482,7 +1488,7 @@
               <UToggle
                 class="ml-2"
                 v-model="notifyOnOwnRunsEnabled"
-                :disabled="!isEditing || isSubmittingFormData"
+                :disabled="runNotificationPreferencesDisabled"
                 :aria-labelledby="notifyOwnRunsToggleLabelId"
               />
             </div>
@@ -1496,7 +1502,7 @@
               <UToggle
                 class="ml-2"
                 v-model="notifyOnLabRunsEnabled"
-                :disabled="!isEditing || isSubmittingFormData"
+                :disabled="runNotificationPreferencesDisabled"
                 :aria-labelledby="notifyLabRunsToggleLabelId"
               />
             </div>
@@ -1510,7 +1516,7 @@
               :id="notifyLabRunsAdditionalEmailsInputId"
               v-model="notifyOnLabRunsAdditionalEmailsInput"
               placeholder="team-distro@example.com, oncall@example.com"
-              :disabled="!isEditing || isSubmittingFormData"
+              :disabled="runNotificationPreferencesDisabled"
             />
             <p v-if="additionalEmailsError" class="text-alert-danger-dark mt-1 text-xs font-medium">
               {{ additionalEmailsError }}
@@ -1526,13 +1532,13 @@
               <UCheckbox
                 label="Succeeds"
                 :model-value="eventFilterSuccessChecked"
-                :disabled="!isEditing || isSubmittingFormData"
+                :disabled="runNotificationPreferencesDisabled"
                 @update:model-value="onToggleNotifySuccesses"
               />
               <UCheckbox
                 label="Fails"
                 :model-value="eventFilterFailureChecked"
-                :disabled="!isEditing || isSubmittingFormData"
+                :disabled="runNotificationPreferencesDisabled"
                 @update:model-value="onToggleNotifyFailures"
               />
             </div>


### PR DESCRIPTION
## Title*
Fix Run Notifications pill hierarchy confusion in Lab Settings

## Type of Change*
- [x] Bug fix
- [x] UI/UX improvement

## Description
The Run Notifications section in Lab Settings has three controls: a lab-wide "Enable run notifications" switch, and two per-user email preferences ("Email me about my own runs" / "Email me about all runs in this lab"). Despite looking like a hierarchy, they're independent controls backed by different records (`Laboratory`, `User`, `LaboratoryUser`).

Turning the lab-wide switch off left the section header badge showing "Off" while the two per-user toggles remained fully interactive — a user could flip them on, and they'd save, while the header contradicted that. This was reported as confusing (see ticket): users want the lab-wide switch and their own preferences to read consistently.

**Fix:**
- The two per-user toggles, the CC-emails input, and the succeed/fail event-filter checkboxes are now disabled (grayed out, values preserved) whenever the lab-wide switch is off, since they have no effect until it's back on.
- Reworded the lab-wide toggle's label to "Enable email notifications for this lab" (previously "Enable run notifications", which was ambiguous about scope — there is no browser-notifications feature in this codebase, everything here is email).
- Updated the hint text to state plainly that this disables the preferences below.
- Header badge stays simple On/Off, now honest about actually gating everything beneath it.

## Testing*
- `pnpm test` in `packages/front-end`: 14 suites / 129 tests passing.
- `pnpm lint` in `packages/front-end`: clean.
- Full pre-commit hook (which also runs `packages/back-end`'s test suite): 109 suites / 802 tests passing.
- Manually verified in `nuxt-dev`: toggling the lab-wide switch off grays out the three dependent controls; toggling it back on restores their previous saved values and re-enables them.

## Impact
Front-end only, scoped to `EGFormLabDetails.vue`. No API or schema changes.

## Additional Information
None.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [ ] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.
