### PR TITLE
fix: Correct Bedrock tooltip to not imply calls run in the lab's own AWS account

### DIFF
--- a/packages/front-end/src/app/components/EGFormLabDetails.vue
+++ b/packages/front-end/src/app/components/EGFormLabDetails.vue
@@ -1225,7 +1225,8 @@
                 <p class="font-medium text-black">Which provider should I choose?</p>
                 <p>
                   <span class="font-medium text-black">Amazon Bedrock</span>
-                  — no API key; the error text stays inside your AWS account. Simplest setup and tightest data control.
+                  — no API key; calls run under the platform's own AWS account and IAM role, not your lab's. Simplest
+                  setup, and the error text stays within AWS, but it isn't isolated to your own AWS account.
                 </p>
                 <p>
                   <span class="font-medium text-black">Anthropic (Claude)</span>


### PR DESCRIPTION
## Title*
Correct Bedrock tooltip to not imply calls run in the lab's own AWS account

## Type of Change*
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [x] UI/UX improvement

## Description
Raised as an inquiry while reviewing the AI Failure Analysis section: the provider-guidance tooltip said Amazon Bedrock's "error text stays inside your AWS account," which reads as if the classification call runs inside the lab's/customer's own AWS environment.

It doesn't. `BedrockClassificationProvider` uses the default AWS SDK credential chain with no credential options — it runs entirely under the platform's own Lambda execution role and AWS account (the `bedrock:InvokeModel` IAM grant in `easy-genomics-nested-stack.ts` is fixed to that Lambda's role, scoped to the platform's own region). There is no per-lab AWS credential, cross-account role assumption, or any mechanism for a lab to route Bedrock calls through its own AWS account — unlike OpenAI/Anthropic, which are genuine BYOK via per-lab SSM `SecureString` API keys.

For a platform serving public-health customers (WSLH, CDC, etc.), that's a meaningful distinction to get right, not just wording. Updated the copy to say calls run under the platform's own account/role rather than the lab's.

## Testing*
- `pnpm lint` and `pnpm test` pass in `packages/front-end` (129 tests).
- Manual: opened Lab Settings → AI Failure Analysis → hovered the info icon next to the intro text, confirmed the updated Bedrock line renders correctly.

## Impact
Copy-only change, one file, no logic/schema/behavior change.

## Additional Information
No functional change to how Bedrock is invoked — this only corrects what the tooltip claims about it. If per-lab AWS accounts for Bedrock is something we actually want to support, that's separate, larger scope (cross-account IAM role assumption) and not part of this PR.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [ ] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.
