### PR TITLE
fix: keep sidebar right border visible behind collapse control

### DIFF
--- a/packages/front-end/src/app/components/EGSidebarNav.vue
+++ b/packages/front-end/src/app/components/EGSidebarNav.vue
@@ -259,6 +259,7 @@
 
   // Stay pinned to the viewport so Collapse remains visible on long pages.
   // Horizontal padding matches the sidebar so the control lines up with nav items.
+  // border-right mirrors the sidebar so the fixed footer does not cover the divider.
   .sidebar-nav__footer {
     position: fixed;
     left: 0;
@@ -268,6 +269,7 @@
     width: var(--sidebar-width);
     padding: 0 2rem 1rem;
     background-color: #ffffff;
+    border-right: 1px solid #e5e5e5;
     transition:
       width 0.2s ease,
       padding 0.2s ease;
@@ -280,6 +282,7 @@
 
   .sidebar-nav--dark .sidebar-nav__footer {
     background-color: #1b1a29;
+    border-right-color: #1b1a29;
   }
 
   // Dark treatment used by the org-admin area to read as a distinct place from the light lab workspace.


### PR DESCRIPTION
## fix: keep sidebar right border visible behind collapse control

## Type of Change*
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Summary
- Restore the sidebar right border behind the fixed Collapse / Expand control
- Match the footer's border color so the divider stays continuous
## Test plan
- [ ] Open a lab page with the sidebar expanded and confirm the right border runs continuously through the Collapse button area
- [ ] Collapse the sidebar and confirm the border still aligns in the narrow state
- [ ] Check an org-admin (dark) sidebar page and confirm no light border appears at the footer
- [ ] Scroll a long page and confirm the Collapse control remains pinned and the border stays visible

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [x] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.