### PR TITLE
fix: stop preset name modal flashing a duplicate error on save

### DIFF
--- a/packages/front-end/src/app/components/EGWorkflowPresetModal.vue
+++ b/packages/front-end/src/app/components/EGWorkflowPresetModal.vue
@@ -51,11 +51,20 @@
 
   const trimmedName = computed<string>(() => name.value.trim());
 
+  /**
+   * The name handed over by the last submit. The preset list refreshes before the modal has
+   * finished closing, so without this the name just saved would read back as already taken.
+   */
+  const submittedName = ref<string | null>(null);
+  // Sync so an edit always clears this before a same-tick submit records the new name.
+  watch(name, () => (submittedName.value = null), { flush: 'sync' });
+
   const nameError = computed<string | null>(() => {
     if (trimmedName.value.length === 0) return null;
     if (trimmedName.value.length > WORKFLOW_RUN_PRESET_NAME_MAX_LENGTH) {
       return `Use ${WORKFLOW_RUN_PRESET_NAME_MAX_LENGTH} characters or fewer.`;
     }
+    if (trimmedName.value === submittedName.value) return null;
     const taken = scope.value === 'LAB' ? props.takenLabNames : props.takenUserNames;
     if (taken.some((existing) => existing.toLowerCase() === trimmedName.value.toLowerCase())) {
       return 'A preset with this name already exists here.';
@@ -79,6 +88,7 @@
       if (!open) return;
       name.value = props.initialName ?? '';
       scope.value = props.initialScope ?? (tierIsFull('USER') && !tierIsFull('LAB') ? 'LAB' : 'USER');
+      submittedName.value = null;
     },
     { immediate: true },
   );
@@ -89,6 +99,7 @@
 
   function submit(): void {
     if (!canSubmit.value) return;
+    submittedName.value = trimmedName.value;
     emit('submit', { name: trimmedName.value, scope: scope.value });
   }
 </script>


### PR DESCRIPTION
## fix: stop preset name modal flashing a duplicate error on save

## Type of Change*
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
When saving a new workflow parameter preset, the name field briefly flashed the
"A preset with this name already exists here." validation error during the modal's
closing animation, even though the save succeeded.
`EGWorkflowPresets.onModalSubmit` awaits `workflowRunPresetsStore.createPreset`, and that
action calls `loadPresets` before it returns. The refreshed list — now including the preset
that was just saved — flowed back into the modal's `takenUserNames`/`takenLabNames` props
while the input still held that name, so `nameError` recomputed to the clash message and
rendered for the duration of the fade-out, before the parent's `modalOpen = false` took effect.
`EGWorkflowPresetModal` now remembers the name it handed to the parent in `submittedName`
and skips the duplicate check for that exact name. It is set on submit, cleared whenever the
user edits the field (with a `sync` flush so an edit always clears it ahead of a same-tick
submit), and cleared again when the modal reopens.

## Testing*
Manual, in a new workflow run stepper on the Edit Parameters step:
- Saved a new preset with a unique name in both the "Only me" and "Everyone in this lab"
  tiers — no error flash, success toast shows, preset appears in the list.
- Typed a name that already exists in the selected tier — the error still appears immediately
  and Save stays disabled.
- Switched tiers with a name that clashes in only one of them — the error appears and clears
  with the tier, as before.
- Saved a preset, reopened the modal and typed that same name — the error correctly appears.
- Renamed an existing preset — unchanged behaviour, no flash.
## Impact
Front-end only, scoped to `EGWorkflowPresetModal`. No API, store, or schema changes; no new
dependencies. Duplicate-name validation is unchanged for every case other than the name the
modal itself just submitted.

## Additional Information
The same props refresh also bumps `userPresetCount`/`labPresetCount`, so when a save fills the
last slot in a tier, that tier's radio option still briefly greys out to "Limit reached — delete
a preset here first." during the fade-out. It shares this root cause but is far less noticeable
than the red error text, so I left it out of this fix — happy to fold it in if reviewers prefer.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [ ] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.