### PR TITLE
fix: allow renaming presets when the tier is at its cap

### DIFF
--- a/packages/front-end/src/app/components/EGWorkflowPresetModal.vue
+++ b/packages/front-end/src/app/components/EGWorkflowPresetModal.vue
@@ -63,8 +63,13 @@
     return null;
   });
 
+  // A full tier only blocks adding a preset; renaming one that is already there is always allowed.
   const canSubmit = computed<boolean>(
-    () => trimmedName.value.length > 0 && !nameError.value && !props.saving && !tierIsFull(scope.value),
+    () =>
+      trimmedName.value.length > 0 &&
+      !nameError.value &&
+      !props.saving &&
+      !(props.mode === 'create' && tierIsFull(scope.value)),
   );
 
   // Reset to the caller's starting values each time the modal opens.


### PR DESCRIPTION
## fix: allow renaming presets when the tier is at its cap

## Type of Change*
- [x] Bug fix

## Description
Once a preset tier held the maximum of 20 presets, the Save button in the rename dialog stayed
disabled, so no preset in that tier could be renamed until one was deleted.

`EGWorkflowPresetModal`'s `canSubmit` applied `!tierIsFull(scope.value)` in both modal modes.
The cap is a create-time rule — a rename adds nothing — and the preset being renamed is itself
one of the 20 filling the tier, so reaching the cap blocked every rename in it. `canSubmit` now
only applies the capacity check when `mode === 'create'`.

This also explains QA's note that a tier below the cap was unaffected: in rename mode `scope`
comes from `initialScope`, the preset's own tier, so only presets in the full tier were blocked.

The back end already treats the cap as create-only — `WorkflowRunPresetService.createPreset`
throws `WorkflowRunPresetLimitReachedError` when siblings are at the limit, while `updatePreset`
only checks for a name collision among siblings excluding the preset being edited. The disabled
button was the sole thing preventing the rename, so no API change is needed.

Creating a preset in a full tier is still blocked exactly as before, and the rename dialog never
showed the capacity messaging (the tier `fieldset` is behind `v-if="mode === 'create'"`), so
there is no leftover "Limit reached" copy contradicting the now-enabled button.

## Testing*
[Replace with what you actually verified. Suggested coverage, using the Pollitzio lab in QA:]
- With 20 presets in "Only you", renamed several of them — Save is enabled and the rename persists.
- With 20 presets in the lab tier, renamed a shared preset — same result.
- At the cap, "Save current values" is still disabled and creating a preset in the full tier is
  still refused.
- At the cap, renaming a preset to a name another preset in the same tier already uses still
  shows the duplicate error and keeps Save disabled.
- Deleted one preset to drop to 19 and confirmed create and rename both behave as before.
- "Update with current values" at the cap still works (it was never cap-gated).

## Impact
Front-end only, a single condition in `EGWorkflowPresetModal`. No API, store, or schema changes
and no new dependencies. The only behaviour change is that the rename dialog no longer consults
tier capacity; creation limits are untouched.

## Additional Information
Filed by QA alongside a separate preset-modal issue (the duplicate-name error flashing on save),
which is fixed on its own branch and PR. The two changes touch the same component but different
computed properties, so expect a small conflict-free overlap if both land close together.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [x] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.