### PR TITLE
feat: soft-deprecate stop offering Seqera to new labs

### DIFF
--- a/packages/front-end/src/app/components/EGFormLabDetails.vue
+++ b/packages/front-end/src/app/components/EGFormLabDetails.vue
@@ -148,13 +148,23 @@
     { value: 'VPC', label: 'VPC' },
   ];
 
+  // Seqera is soft-deprecated: only labs that already have it enabled keep seeing the
+  // integration section. Based on the server-loaded snapshot (unedited-lab-details), not the
+  // live toggle state, so an admin disabling Seqera on an already-enabled lab doesn't lose the
+  // section mid-edit. Create mode never loads a snapshot, so this is always false there.
+  const isSeqeraAlreadyEnabled = computed(() => uneditedLabDetails.value?.NextFlowTowerEnabled === true);
+
   // Badge state for the always-visible collapsible settings cards — reflects whether the
   // section is actually in effect right now, not just whether its fields are populated.
   const integrationsBadges = computed(() => [
-    {
-      label: `Seqera ${state.value.NextFlowTowerEnabled ? 'On' : 'Off'}`,
-      tone: state.value.NextFlowTowerEnabled ? 'positive' : 'neutral',
-    } as const,
+    ...(isSeqeraAlreadyEnabled.value
+      ? [
+          {
+            label: `Seqera ${state.value.NextFlowTowerEnabled ? 'On' : 'Off'}`,
+            tone: state.value.NextFlowTowerEnabled ? 'positive' : 'neutral',
+          } as const,
+        ]
+      : []),
     {
       label: `HealthOmics ${state.value.AwsHealthOmicsEnabled ? 'On' : 'Off'}`,
       tone: state.value.AwsHealthOmicsEnabled ? 'positive' : 'neutral',
@@ -1118,7 +1128,11 @@
       <EGCollapsibleSection
         heading-id="lab-settings-integrations-heading"
         title="Integrations"
-        description="Seqera and HealthOmics connections for this lab."
+        :description="
+          isSeqeraAlreadyEnabled
+            ? 'Seqera and HealthOmics connections for this lab.'
+            : 'HealthOmics connections for this lab.'
+        "
         :badges="isLoadingFormData ? [] : integrationsBadges"
       >
         <!-- Don't render Seqera/HealthOmics Off from defaultState while lab details are still loading. -->
@@ -1133,7 +1147,7 @@
           </div>
         </div>
         <template v-else>
-          <section :aria-labelledby="seqeraSectionId">
+          <section v-if="isSeqeraAlreadyEnabled" :aria-labelledby="seqeraSectionId">
             <h3 :id="seqeraSectionId" class="sr-only">Seqera integration</h3>
 
             <!-- Next Flow Tower: Toggle -->
@@ -1339,7 +1353,8 @@
           </div>
 
           <p v-if="!state.AwsHealthOmicsEnabled && !state.NextFlowTowerEnabled" class="text-muted text-xs">
-            Enable HealthOmics or Seqera integration above to configure AI failure analysis for that integration.
+            Enable HealthOmics{{ isSeqeraAlreadyEnabled ? ' or Seqera' : '' }} integration above to configure AI
+            failure analysis for that integration.
           </p>
 
           <!-- HealthOmics sub-section -->

--- a/packages/front-end/tests/e2e/org-admin/Labs_Org_Admin.spec.e2e.ts
+++ b/packages/front-end/tests/e2e/org-admin/Labs_Org_Admin.spec.e2e.ts
@@ -167,11 +167,8 @@ test('03 - Create a Laboratory Successfully', async ({ page, baseURL }) => {
   await page.getByPlaceholder('Describe your lab and what').fill('Playwright test lab description');
   await page.getByLabel('Default S3 bucket directory').click();
   await page.getByText(envConfig.testS3Url).click();
-  await page.getByLabel('Enable Seqera Integration').check();
-  await page.getByLabel('Workspace ID').click();
-  await page.getByLabel('Workspace ID').fill(envConfig.testWorkspaceId);
-  await page.getByLabel('Personal Access Token').click();
-  await page.getByLabel('Personal Access Token').fill(envConfig.testAccessToken);
+  // Seqera is soft-deprecated for new labs: the "Enable Seqera Integration" toggle is not
+  // offered here, so nothing to check/fill.
   await page.getByRole('button', { name: 'Create Lab' }).click();
   page.getByRole('cell', { name: 'Playwright test lab' });
   page.getByRole('cell', { name: 'Playwright test lab description' });
@@ -210,11 +207,8 @@ test('04 - Update a Laboratory Successfully', async ({ page, baseURL }) => {
     await page.getByPlaceholder('Enter lab name (required and').fill(labNameUpdated);
     await page.getByPlaceholder('Describe your lab and what').click();
     await page.getByPlaceholder('Describe your lab and what').fill('Automation test lab description');
-    await page.getByLabel('Enable Seqera Integration').check();
-    await page.getByLabel('Workspace ID').click();
-    await page.getByLabel('Workspace ID').fill(envConfig.testWorkspaceId);
-    await page.getByLabel('Personal Access Token').click();
-    await page.getByLabel('Personal Access Token').fill(envConfig.testAccessToken);
+    // This lab was created without Seqera enabled (test 03), so the "Enable Seqera Integration"
+    // section is soft-deprecated and hidden here too — nothing to check/fill.
 
     await page.getByRole('button', { name: 'Save Changes' }).click();
     await page.waitForTimeout(2000);


### PR DESCRIPTION
## Type of Change
- [x] New feature

## Description
First step of the Seqera deprecation (team decision, 2026-08-06): stop offering Seqera as an option for labs that don't already have it enabled, without touching anything for labs that already have it.

In `EGFormLabDetails.vue`, added a computed `isSeqeraAlreadyEnabled` — true only when the lab's server-loaded snapshot (`uneditedLabDetails`) already had `NextFlowTowerEnabled === true`. It's based on the loaded snapshot rather than the live toggle so an admin unchecking Seqera on an already-enabled lab doesn't lose the section mid-edit. This gates:
- The whole "Enable Seqera Integration" `<section>` (toggle + Endpoint URL + Workspace ID + Personal Access Token fields).
- The "Seqera On/Off" badge on the Integrations card header.
- The Integrations card's description text and the AI Failure Analysis empty-state hint, so neither still mentions Seqera when it isn't offered.

Scope note: this hides the section for **any** lab without Seqera already enabled — new labs and any pre-existing lab that never turned it on — not just brand-new creations, per the ticket body's literal wording (confirmed with the requester).

**Investigation (ticket's second part):** confirmed no back-end/CDK/schema change is needed. `create-laboratory.lambda.ts` never calls `LaboratoryWorkflowAccessService` — no SEQERA workflow-access row is auto-granted to new labs today; per-workflow ALLOW/DENY rows are only created when an org admin explicitly edits the Workflow Access allowlist. So not offering the toggle in the UI is sufficient.

Also updated `Labs_Org_Admin.spec.e2e.ts`: removed the Seqera-toggle steps from the create/update lab E2E tests, since the lab they exercise no longer has Seqera enabled.

**Out of scope:** removing Seqera back-end code, CDK resources, or shared-lib types/schemas (separate hard-removal epic); any change to labs that already have Seqera enabled.

## Testing
- `pnpm --filter front-end test` — 129/129 tests passing, 0 lint errors (no regressions; no dedicated component test exists for `EGFormLabDetails.vue`, consistent with this repo's convention of front-end unit tests covering only `app/utils/` pure functions).
- Pre-commit hook ran shared-lib OpenAPI regen + the full back-end test suite (109 suites / 802 tests) — all passing, since this change touches no back-end code but the hook runs regardless.
- Not yet verified: the two manual QA cases (new lab shows no Seqera section; existing Seqera-enabled lab is unchanged) are logged in `TESTING.md` as "Not yet executed," pending a manual pass against a deployed environment.
- The updated `Labs_Org_Admin.spec.e2e.ts` steps have not been run — Playwright E2E runs against a deployed `quality` environment, not locally.

## Impact
Front-end only, presentation-level change (Vue template/computed logic in one component, plus its E2E test). No back-end, CDK, schema, or API changes. No new dependencies. No behavior change for labs that already have `NextFlowTowerEnabled = true`.

## Additional Information
None.

## Checklist
- [x] No new errors or warnings have been introduced.
- [ ] All tests pass successfully and new tests added as necessary. *(automated front-end/back-end suites pass; the two manual QA cases and the E2E update are not yet executed — see Testing)*
- [ ] Documentation has been updated accordingly. *(N/A — QA notes added to TESTING.md; no user-facing docs affected)*
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.
