### PR TITLE
fix: cancel runs with externalrunid instead of internal runid

### DIFF
--- a/packages/front-end/src/app/components/EGLabView.vue
+++ b/packages/front-end/src/app/components/EGLabView.vue
@@ -755,6 +755,8 @@
     const runId = runToCancel.value?.RunId;
     const runName = runToCancel.value?.RunName;
     const runPlatform = runToCancel.value?.Platform;
+    // Cancellation targets the compute platform's own run id, not the Easy Genomics RunId.
+    const externalRunId = runToCancel.value?.ExternalRunId;
 
     if (!runId || !runName || !runPlatform) {
       throw new Error('runToCancel is missing required information');
@@ -762,13 +764,19 @@
 
     const statusAtCancel = runToCancel.value?.Status || 'unknown';
 
+    if (!externalRunId) {
+      useToastStore().error('This run is not yet registered with its compute platform, so it cannot be cancelled');
+      isCancelDialogOpen.value = false;
+      return;
+    }
+
     try {
       if (runPlatform === 'Seqera Cloud') {
         uiStore.setRequestPending('cancelSeqeraRun');
-        await $api.seqeraRuns.cancelPipelineRun(props.labId, runId);
+        await $api.seqeraRuns.cancelPipelineRun(props.labId, externalRunId);
       } else {
         uiStore.setRequestPending('cancelOmicsRun');
-        await $api.omicsRuns.cancelWorkflowRun(props.labId, runId);
+        await $api.omicsRuns.cancelWorkflowRun(props.labId, externalRunId);
       }
       // Analytics: run cancelled (platform + status only; no run name / id).
       useAnalytics().track('run_cancelled', {


### PR DESCRIPTION
## fix: cancel runs with externalrunid instead of internal runid

## Type of Change*
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Cancelling an AWS HealthOmics run from the lab's Runs table failed with a generic
"Failed to cancel run" toast, backed by a 400 `EG-100` response from
`PUT /aws-healthomics/run/cancel-run-execution/{id}`.
`handleCancelDialogAction` in `EGLabView.vue` was passing `LaboratoryRun.RunId`
(the Easy Genomics UUID) as the path parameter. The `cancel-run-execution` Lambda
forwards that value straight to `omics:CancelRun`, so IAM evaluated the request
against `arn:aws:omics:<region>:<account>:run/<uuid>` — a run that does not exist.
The omics access role only permits `CancelRun` when the target run's
`LaboratoryId` / `OrganizationId` tags match the assumed session's principal tags,
and a non-existent run carries no tags, so the condition could never match. AWS
therefore returned AccessDenied rather than a not-found error, which is why the
failure looked like a permissions problem:
> User: arn:aws:sts::…:assumed-role/dev-quality-easy-genomics-omics-access-role/lab-omics-session-… is not authorized to …
Every other HealthOmics call from the UI (`read-run`, `read-run-tasks`, run output
path resolution) already uses `LaboratoryRun.ExternalRunId`; cancel was the only
one using `RunId`. The Seqera branch of the same function had the identical bug,
since `nf-tower/workflow/cancel-workflow-execution` expects a Nextflow Tower
workflow id.
Changes:
- Pass `ExternalRunId` to both `omicsRuns.cancelWorkflowRun` and
  `seqeraRuns.cancelPipelineRun`.
- Bail out with a specific toast when `ExternalRunId` is absent. The Cancel Run
  action is offered for `SUBMITTED` runs, which can exist before `StartRun`
  returns an id; previously that path sent a bogus id and produced the same
  misleading AccessDenied.
No back-end or IAM changes: the API contract stays consistent with the other
run endpoints, which all take the external platform id as the path parameter.

## Testing*
- Started a HealthOmics run, cancelled it from the Runs table while `RUNNING`,
  and confirmed the request now targets the HealthOmics run id, returns 200, and
  the run transitions to `STOPPING`/`CANCELLED` with no error toast.
- Verified the Seqera cancel path still cancels a running pipeline.
- Confirmed the guard shows the new message instead of firing a request when a
  run has no `ExternalRunId`.

## Impact
Front-end only, scoped to the cancel action in `EGLabView.vue`. No API, IAM, or
schema changes, so nothing to redeploy on the back end.
Note for reviewers: runs created before `create-run-execution` began tagging runs
with `LaboratoryId` / `OrganizationId` still fail the IAM tag condition and cannot
be cancelled. That is pre-existing and out of scope here.

## Additional Information
The `cancel-run-execution` Lambda is granted `dynamodb:Query` on the
`laboratory-run-table` but never uses it, which suggests the original intent was
for the back end to resolve `RunId` to `ExternalRunId` itself. This PR keeps
resolution in the UI for consistency with the sibling endpoints; that unused
permission is the hook if we'd rather move it server-side later.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [ ] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.