### PR TITLE
fix: coalesce concurrent loadWorkflowsForLab requests for same lab

### DIFF
--- a/packages/back-end/src/app/utils/omics-shared-workflow-utils.ts
+++ b/packages/back-end/src/app/utils/omics-shared-workflow-utils.ts
@@ -33,6 +33,39 @@ export type SharedWorkflowSummary = {
   ownerAccountId?: string;
 };
 
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isTooManyRequestsError(error: unknown): boolean {
+  const err = error as { name?: string; $metadata?: { httpStatusCode?: number } };
+  return err?.name === 'TooManyRequestsException' || err?.$metadata?.httpStatusCode === 429;
+}
+
+/**
+ * ListShares is aggressively rate-limited; SDK default retries (~3 attempts, sub-second
+ * backoff) are often insufficient under concurrent lab-page loads.
+ */
+async function listSharedWorkflowsPage(
+  omicsService: Pick<OmicsService, 'listSharedWorkflows'>,
+  input: ListSharesCommandInput,
+  maxAttempts = 5,
+): Promise<Awaited<ReturnType<OmicsService['listSharedWorkflows']>>> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await omicsService.listSharedWorkflows(input);
+    } catch (error) {
+      lastError = error;
+      if (!isTooManyRequestsError(error) || attempt === maxAttempts) {
+        throw error;
+      }
+      await sleep(Math.min(1000 * 2 ** (attempt - 1), 8000));
+    }
+  }
+  throw lastError;
+}
+
 /**
  * Paginates ListShares (resourceOwner OTHER) and returns ACTIVE shared workflows.
  */
@@ -42,7 +75,7 @@ export async function listAllSharedWorkflowSummaries(
   const out: SharedWorkflowSummary[] = [];
   let nextToken: string | undefined;
   do {
-    const page = await omicsService.listSharedWorkflows(<ListSharesCommandInput>{
+    const page = await listSharedWorkflowsPage(omicsService, <ListSharesCommandInput>{
       resourceOwner: 'OTHER',
       maxResults: 100,
       nextToken,

--- a/packages/back-end/test/app/utils/omics-shared-workflow-utils.test.ts
+++ b/packages/back-end/test/app/utils/omics-shared-workflow-utils.test.ts
@@ -1,9 +1,46 @@
 import {
+  listAllSharedWorkflowSummaries,
   ownerAccountIdFromOmicsShare,
   resolveSharedWorkflowOwnerId,
 } from '../../../src/app/utils/omics-shared-workflow-utils';
 
 describe('omics-shared-workflow-utils', () => {
+  describe('listAllSharedWorkflowSummaries', () => {
+    it('retries TooManyRequestsException then returns ACTIVE shares', async () => {
+      jest.useFakeTimers();
+      try {
+        const tooMany = Object.assign(new Error('Too Many Requests'), {
+          name: 'TooManyRequestsException',
+          $metadata: { httpStatusCode: 429 },
+        });
+        const omicsService = {
+          listSharedWorkflows: jest
+            .fn()
+            .mockRejectedValueOnce(tooMany)
+            .mockResolvedValueOnce({
+              shares: [
+                {
+                  resourceId: 'wf-shared',
+                  shareName: 'Shared WF',
+                  ownerId: '111122223333',
+                  status: 'ACTIVE',
+                },
+              ],
+            }),
+        };
+
+        const resultPromise = listAllSharedWorkflowSummaries(omicsService);
+        await jest.advanceTimersByTimeAsync(1000);
+        await expect(resultPromise).resolves.toEqual([
+          { id: 'wf-shared', name: 'Shared WF', ownerAccountId: '111122223333' },
+        ]);
+        expect(omicsService.listSharedWorkflows).toHaveBeenCalledTimes(2);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+  });
+
   describe('ownerAccountIdFromOmicsShare', () => {
     it('prefers ownerId', () => {
       expect(

--- a/packages/front-end/src/app/stores/omicsWorkflows.ts
+++ b/packages/front-end/src/app/stores/omicsWorkflows.ts
@@ -19,6 +19,9 @@ const initialState = (): OmicsWorkflowsStoreState => ({
   workflowIdsByLab: {},
 });
 
+/** Coalesce concurrent loads for the same lab (EGLabView + EGDashboard both call this). */
+const loadWorkflowsInflight = new Map<string, Promise<void>>();
+
 const useOmicsWorkflowsStore = defineStore('omicsWorkflowsStore', {
   state: initialState,
 
@@ -31,55 +34,68 @@ const useOmicsWorkflowsStore = defineStore('omicsWorkflowsStore', {
 
   actions: {
     reset() {
+      loadWorkflowsInflight.clear();
       Object.assign(this, initialState());
     },
 
     async loadWorkflowsForLab(labId: string): Promise<void> {
-      const { $api } = useNuxtApp();
-
-      const [privateRes, sharedRes] = await Promise.all([
-        $api.omicsWorkflows.list(labId),
-        $api.omicsWorkflows.listShared(labId).catch((err) => {
-          console.error('Failed to load shared Omics workflows', err);
-          useToastStore().error('Failed to load shared workflows. Please refresh.');
-          return { items: [] as LabOmicsWorkflow[] };
-        }),
-      ]);
-
-      if (!privateRes.items) {
-        throw new Error('list omics workflows response did not contain data');
+      const existing = loadWorkflowsInflight.get(labId);
+      if (existing) {
+        return existing;
       }
 
-      this.workflowIdsByLab[labId] = [];
-      const seen = new Set<string>();
+      const loadPromise = (async () => {
+        const { $api } = useNuxtApp();
 
-      const addWorkflowRow = (workflowId: string, row: LabOmicsWorkflow) => {
-        if (seen.has(workflowId)) {
-          return;
-        }
-        seen.add(workflowId);
-        this.workflows[workflowId] = row;
-        this.workflowIdsByLab[labId].push(workflowId);
-      };
+        const [privateRes, sharedRes] = await Promise.all([
+          $api.omicsWorkflows.list(labId),
+          $api.omicsWorkflows.listShared(labId).catch((err) => {
+            console.error('Failed to load shared Omics workflows', err);
+            useToastStore().error('Failed to load shared workflows. Please refresh.');
+            return { items: [] as LabOmicsWorkflow[] };
+          }),
+        ]);
 
-      for (const workflow of privateRes.items) {
-        if (!workflow.id) {
-          continue;
+        if (!privateRes.items) {
+          throw new Error('list omics workflows response did not contain data');
         }
-        addWorkflowRow(workflow.id, { ...workflow, source: 'PRIVATE' });
-      }
 
-      for (const workflow of sharedRes.items ?? []) {
-        if (!workflow.id) {
-          continue;
+        this.workflowIdsByLab[labId] = [];
+        const seen = new Set<string>();
+
+        const addWorkflowRow = (workflowId: string, row: LabOmicsWorkflow) => {
+          if (seen.has(workflowId)) {
+            return;
+          }
+          seen.add(workflowId);
+          this.workflows[workflowId] = row;
+          this.workflowIdsByLab[labId].push(workflowId);
+        };
+
+        for (const workflow of privateRes.items) {
+          if (!workflow.id) {
+            continue;
+          }
+          addWorkflowRow(workflow.id, { ...workflow, source: 'PRIVATE' });
         }
-        addWorkflowRow(workflow.id, {
-          id: workflow.id,
-          name: workflow.name,
-          source: 'SHARED',
-          ...(workflow.ownerAccountId ? { ownerAccountId: workflow.ownerAccountId } : {}),
-        });
-      }
+
+        for (const workflow of sharedRes.items ?? []) {
+          if (!workflow.id) {
+            continue;
+          }
+          addWorkflowRow(workflow.id, {
+            id: workflow.id,
+            name: workflow.name,
+            source: 'SHARED',
+            ...(workflow.ownerAccountId ? { ownerAccountId: workflow.ownerAccountId } : {}),
+          });
+        }
+      })().finally(() => {
+        loadWorkflowsInflight.delete(labId);
+      });
+
+      loadWorkflowsInflight.set(labId, loadPromise);
+      return loadPromise;
     },
   },
 


### PR DESCRIPTION
## Title*
Fix intermittent "Failed to load shared workflows" toast on lab page load

## Type of Change*
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Intermittent UI toast **"Failed to load shared workflows. Please refresh."** was caused by AWS HealthOmics `ListShares` rate limiting (`TooManyRequestsException` / 429), amplified because the lab page called `loadWorkflowsForLab` twice in parallel (`EGLabView` + `EGDashboard`).

Changes:
- **Front-end:** Coalesce concurrent `loadWorkflowsForLab` calls for the same lab so only one private + one shared list request runs.
- **Back-end:** Retry `ListShares` on 429 with exponential backoff (SDK default retries were too short under burst load).

Related: EGV-219

## Testing*
- Reproduced double-fetch on lab dashboard load; confirmed post-fix coalescing (one unique load + one joined caller; single `list-shared-workflows` request returning 200).
- CloudWatch on demo showed `TooManyRequestsException` on `list-shared-workflows` under concurrent load.
- Added unit test: `listAllSharedWorkflowSummaries` retries `TooManyRequestsException` then returns ACTIVE shares (`omics-shared-workflow-utils.test.ts`).

## Impact
- Fewer duplicate Omics list calls on lab page load (better UX, lower chance of 429 toasts).
- Shared-workflow listing may take slightly longer when Omics is rate-limiting (backoff up to ~8s per retry, max 5 attempts).
- Backend retry requires deploy to take effect in deployed environments; FE coalescing applies as soon as the front-end change ships.

## Additional Information
Lab ID timing was ruled out — `laboratoryId` was always present. Private workflow listing was often fine while shared listing failed, which matches `ListShares`-specific throttling.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [x] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.