### PR TITLE
fix: Bundle @aws-sdk/client-omics into create/update-laboratory Lambdas

### DIFF
--- a/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
+++ b/packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts
@@ -262,11 +262,13 @@ export class EasyGenomicsNestedStack extends NestedStack {
           environment: {
             SEQERA_API_BASE_URL: this.props.seqeraApiBaseUrl,
           },
+          nodeModules: ['@aws-sdk/client-omics'],
         },
         '/easy-genomics/laboratory/update-laboratory': {
           environment: {
             SEQERA_API_BASE_URL: this.props.seqeraApiBaseUrl,
           },
+          nodeModules: ['@aws-sdk/client-omics'],
         },
         '/easy-genomics/laboratory/delete-laboratory': {
           environment: {


### PR DESCRIPTION
## Title*
Bundle @aws-sdk/client-omics into create/update-laboratory Lambdas

## Type of Change*
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
QA reported that saving Lab Settings with HealthOmics VPC Networking configured showed the error `import_client_omics.GetConfigurationCommand is not a constructor`. This worked fine locally, which pointed at a deploy-environment-specific bundling issue rather than a code bug.

Root cause: every Lambda in this repo bundles with `externalModules: ['@aws-sdk/*']` (`lambda-construct.ts:168`), so `@aws-sdk/*` imports resolve from the AWS-managed Lambda Node.js 20.x runtime's own pre-installed SDK at runtime, not from the pinned `@aws-sdk/client-omics@^3.1090.0` in `package.json`. HealthOmics' "Configuration" API (used for custom VPC networking) is new enough that it's missing from whatever SDK snapshot the managed runtime ships, so `GetConfigurationCommand` is `undefined` there — hence "is not a constructor". `create-laboratory.lambda.ts` and `update-laboratory.lambda.ts` both call `assertHealthOmicsVpcConfigurationIsActive`, which calls `OmicsService.getConfiguration()` → `new GetConfigurationCommand(...)`.

Fix: add `nodeModules: ['@aws-sdk/client-omics']` to those two Lambda entries in `easy-genomics-nested-stack.ts`, which forces esbuild to install the actual pinned package into the deployment artifact instead of relying on the runtime's copy — the same escape-hatch mechanism already used for `nodeModules: ['swagger-ui-dist']` elsewhere in this stack.

## Testing*
- `pnpm lint` and `pnpm test` pass in `packages/back-end` (110 suites, 808 tests).
- **This bug cannot be reproduced or verified via `pnpm local-server`** — that runs the Lambda handler directly against the real installed `node_modules` (which already has `GetConfigurationCommand`), bypassing the esbuild `externalModules` step entirely where the bug actually lives. Verification requires deploying this branch's back-end to a real AWS stack (`pnpm build-back-end && pnpm deploy` from `packages/back-end`) and repeating the QA repro: Lab Settings → enable HealthOmics → VPC Networking → set a VPC configuration name → Save Changes. Expect either a successful save or a legitimate specific validation error (EG-309/EG-310), not the constructor crash.

## Impact
Back-end only (`packages/back-end/src/infra/stacks/easy-genomics-nested-stack.ts`). Slightly larger deployed bundle size for these two Lambdas (now includes `@aws-sdk/client-omics` instead of relying on the runtime's copy); no behavior change for any other Lambda.

## Additional Information
No other Lambda calls the HealthOmics Configuration API family (`GetConfigurationCommand`/`CreateConfigurationCommand`/etc.), so no other functions need this override today. If future code adds calls to newer AWS SDK API surfaces from other Lambdas, the same `externalModules`-vs-runtime-SDK mismatch could recur elsewhere — worth keeping in mind.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [ ] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.
