### PR TITLE
fix: skip API diff when base branch has no baseline spec

### DIFF
--- a/.github/workflows/api-diff-check.yml
+++ b/.github/workflows/api-diff-check.yml
@@ -51,7 +51,12 @@ jobs:
         id: diff
         run: |-
           set -euo pipefail
-          git show "origin/${GITHUB_BASE_REF}:packages/shared-lib/src/app/openapi/easy-genomics-api.yaml" > /tmp/api-base.yaml
+          # The spec has no baseline to diff against when it does not exist in the base branch yet
+          # (first release PR into a long-lived branch, or the PR adds the spec).
+          if ! git show "origin/${GITHUB_BASE_REF}:packages/shared-lib/src/app/openapi/easy-genomics-api.yaml" > /tmp/api-base.yaml 2>/dev/null; then
+            echo "### ℹ️ API diff: no baseline spec in origin/${GITHUB_BASE_REF}, skipping diff" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
 
           # No changes — annotate step summary and exit
           if diff -q /tmp/api-base.yaml packages/shared-lib/src/app/openapi/easy-genomics-api.yaml > /dev/null 2>&1; then

--- a/projenrc/github-actions-api-diff-check.ts
+++ b/projenrc/github-actions-api-diff-check.ts
@@ -60,7 +60,12 @@ export class GithubActionsApiDiffCheck extends Component {
             name: 'Run optic diff',
             run: [
               'set -euo pipefail',
-              'git show "origin/${GITHUB_BASE_REF}:packages/shared-lib/src/app/openapi/easy-genomics-api.yaml" > /tmp/api-base.yaml',
+              '# The spec has no baseline to diff against when it does not exist in the base branch yet',
+              '# (first release PR into a long-lived branch, or the PR adds the spec).',
+              'if ! git show "origin/${GITHUB_BASE_REF}:packages/shared-lib/src/app/openapi/easy-genomics-api.yaml" > /tmp/api-base.yaml 2>/dev/null; then',
+              '  echo "### ℹ️ API diff: no baseline spec in origin/${GITHUB_BASE_REF}, skipping diff" >> "$GITHUB_STEP_SUMMARY"',
+              '  exit 0',
+              'fi',
               '',
               '# No changes — annotate step summary and exit',
               'if diff -q /tmp/api-base.yaml packages/shared-lib/src/app/openapi/easy-genomics-api.yaml > /dev/null 2>&1; then',


### PR DESCRIPTION
## Fix api-diff-check failing when the OpenAPI spec is absent from the base branch

## Type of Change*
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
The `api-diff-check / API schema diff check` job fails on release PRs into `staging`, for example
https://github.com/dept/easy-genomics/pull/914 (job `97931133765`), with:
`fatal: path 'packages/shared-lib/src/app/openapi/easy-genomics-api.yaml' exists on disk, but not in 'origin/staging'`
The `Run optic diff` step ran `git show "origin/${GITHUB_BASE_REF}:...easy-genomics-api.yaml"` unguarded
under `set -euo pipefail`. The OpenAPI spec was introduced on `development` and has not reached `staging`
yet, so there is no baseline blob to read and the step aborts before any diff is attempted. This is not a
schema problem: the same command resolves fine against `origin/development`, which is why day-to-day PRs
into `development` pass while the release PR fails.
This change guards the baseline lookup. When the spec does not exist in the base branch, the step records a
note in the job summary and exits 0 instead of failing the job. When a baseline does exist, behaviour is
unchanged.
Because `.github/workflows/api-diff-check.yml` is generated by projen, the fix is made in
`projenrc/github-actions-api-diff-check.ts` and the workflow was regenerated with `pnpm exec projen`.
Editing the YAML directly would be reverted on the next projen run.

## Testing*
- Confirmed the root cause locally: `git show origin/staging:packages/shared-lib/src/app/openapi/easy-genomics-api.yaml`
  fails, while the same path resolves on `origin/development`.
- Ran the new step logic locally against both branches. With `staging` as the base it exits 0 and writes the
  "no baseline spec" note to the step summary; with `development` it captures the 10,862-line baseline and
  proceeds to the real diff.
- Re-ran `pnpm exec projen` and verified the only YAML change is the new guard.
- Verified `prettier --check` passes on the modified projenrc file.

## Impact
CI-only; no application or runtime code is touched. Since the step now exits before setting `has_changes`,
the downstream "Post diff as PR comment" and "Fail on breaking changes without label" steps are skipped in
the no-baseline case, so no empty or misleading diff comment is posted. Breaking-change detection is
unaffected whenever a baseline exists, so the check does not become weaker for normal PRs.

## Additional Information
`pull_request` workflows run from the merge of head into base, so PR #914 will only pick this up once the fix
is merged into `development` and that PR is synchronised or re-run. Also note that after #914 merges,
`staging` will contain the spec, so the next `development` -> `staging` PR gets a genuine comparison; if that
first real diff surfaces breaking changes the job will fail unless the PR carries the `breaking-change`
label, which is the check behaving as designed rather than a regression from this fix.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [x] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.