### PR TITLE
fix: HealthOmics AI Failure Analysis LLM key/model reuse across providers

### DIFF
--- a/packages/back-end/src/app/controllers/easy-genomics/laboratory/update-laboratory.lambda.ts
+++ b/packages/back-end/src/app/controllers/easy-genomics/laboratory/update-laboratory.lambda.ts
@@ -69,6 +69,17 @@ export const handler: Handler = async (
       throw new LaboratorySeqeraCredentialsIncorrectError();
     }
 
+    // A saved API key is scoped to whichever provider it was entered for. If the admin
+    // switches HealthOmics LLM provider to one that requires a key (openai/anthropic),
+    // the previously-saved key belongs to the old provider and must not be silently reused.
+    if (
+      (request.HealthOmicsLlmProvider === 'openai' || request.HealthOmicsLlmProvider === 'anthropic') &&
+      request.HealthOmicsLlmProvider !== existing.HealthOmicsLlmProvider &&
+      !request.HealthOmicsLlmApiKey
+    ) {
+      throw new InvalidRequestError('A new API key is required when changing the AI Failure Analysis provider.');
+    }
+
     // Re-validated on every save while mode stays VPC, even for edits unrelated to networking
     // (e.g. renaming a disabled lab). If ops deletes the referenced Configuration, such a lab
     // becomes un-editable until an admin switches mode back to RESTRICTED — an accepted tradeoff

--- a/packages/back-end/test/app/controllers/easy-genomics/laboratory/update-laboratory.lambda.test.ts
+++ b/packages/back-end/test/app/controllers/easy-genomics/laboratory/update-laboratory.lambda.test.ts
@@ -429,6 +429,134 @@ describe('update-laboratory.lambda', () => {
     });
   });
 
+  it('returns 400 when HealthOmics LLM provider changes to openai without a new API key', async () => {
+    (mockLabService.prototype.queryByLaboratoryId as jest.Mock).mockResolvedValue({
+      OrganizationId: ORG_ID,
+      LaboratoryId: LAB_ID,
+      AwsHealthOmicsEnabled: true,
+      HealthOmicsLlmProvider: 'anthropic',
+    });
+
+    const result = await handler(
+      createEvent(LAB_ID, {
+        ...baseRequest,
+        NextFlowTowerEnabled: false,
+        NextFlowTowerApiBaseUrl: undefined,
+        NextFlowTowerWorkspaceId: undefined,
+        NextFlowTowerAccessToken: undefined,
+        HealthOmicsLlmProvider: 'openai',
+        HealthOmicsLlmModelId: 'gpt-4o',
+      }),
+      createContext(),
+      () => {},
+    );
+
+    expect(result.statusCode).toBe(400);
+    expect(mockLabService.prototype.update).not.toHaveBeenCalled();
+  });
+
+  it('allows the HealthOmics LLM provider change to openai when a new API key is supplied', async () => {
+    (mockLabService.prototype.queryByLaboratoryId as jest.Mock).mockResolvedValue({
+      OrganizationId: ORG_ID,
+      LaboratoryId: LAB_ID,
+      AwsHealthOmicsEnabled: true,
+      HealthOmicsLlmProvider: 'anthropic',
+    });
+
+    (mockLabService.prototype.update as jest.Mock).mockResolvedValue({
+      OrganizationId: ORG_ID,
+      LaboratoryId: LAB_ID,
+    });
+
+    const result = await handler(
+      createEvent(LAB_ID, {
+        ...baseRequest,
+        NextFlowTowerEnabled: false,
+        NextFlowTowerApiBaseUrl: undefined,
+        NextFlowTowerWorkspaceId: undefined,
+        NextFlowTowerAccessToken: undefined,
+        HealthOmicsLlmProvider: 'openai',
+        HealthOmicsLlmModelId: 'gpt-4o',
+        HealthOmicsLlmApiKey: 'new-openai-key',
+      }),
+      createContext(),
+      () => {},
+    );
+
+    expect(result.statusCode).toBe(200);
+    expect(mockSsmService.prototype.putParameter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        Name: `/easy-genomics/organization/${ORG_ID}/laboratory/${LAB_ID}/llm-api-key-healthomics`,
+        Value: 'new-openai-key',
+      }),
+    );
+  });
+
+  it('allows saving without a new API key when the HealthOmics LLM provider is unchanged', async () => {
+    (mockLabService.prototype.queryByLaboratoryId as jest.Mock).mockResolvedValue({
+      OrganizationId: ORG_ID,
+      LaboratoryId: LAB_ID,
+      AwsHealthOmicsEnabled: true,
+      HealthOmicsLlmProvider: 'openai',
+    });
+
+    (mockLabService.prototype.update as jest.Mock).mockResolvedValue({
+      OrganizationId: ORG_ID,
+      LaboratoryId: LAB_ID,
+    });
+
+    const result = await handler(
+      createEvent(LAB_ID, {
+        ...baseRequest,
+        NextFlowTowerEnabled: false,
+        NextFlowTowerApiBaseUrl: undefined,
+        NextFlowTowerWorkspaceId: undefined,
+        NextFlowTowerAccessToken: undefined,
+        HealthOmicsLlmProvider: 'openai',
+        HealthOmicsLlmModelId: 'gpt-4o',
+      }),
+      createContext(),
+      () => {},
+    );
+
+    expect(result.statusCode).toBe(200);
+    expect(mockSsmService.prototype.putParameter).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        Name: `/easy-genomics/organization/${ORG_ID}/laboratory/${LAB_ID}/llm-api-key-healthomics`,
+      }),
+    );
+  });
+
+  it('allows switching the HealthOmics LLM provider to bedrock without an API key', async () => {
+    (mockLabService.prototype.queryByLaboratoryId as jest.Mock).mockResolvedValue({
+      OrganizationId: ORG_ID,
+      LaboratoryId: LAB_ID,
+      AwsHealthOmicsEnabled: true,
+      HealthOmicsLlmProvider: 'anthropic',
+    });
+
+    (mockLabService.prototype.update as jest.Mock).mockResolvedValue({
+      OrganizationId: ORG_ID,
+      LaboratoryId: LAB_ID,
+    });
+
+    const result = await handler(
+      createEvent(LAB_ID, {
+        ...baseRequest,
+        NextFlowTowerEnabled: false,
+        NextFlowTowerApiBaseUrl: undefined,
+        NextFlowTowerWorkspaceId: undefined,
+        NextFlowTowerAccessToken: undefined,
+        HealthOmicsLlmProvider: 'bedrock',
+        HealthOmicsLlmModelId: 'anthropic.claude-3-sonnet',
+      }),
+      createContext(),
+      () => {},
+    );
+
+    expect(result.statusCode).toBe(200);
+  });
+
   it('asserts S3 access when S3Bucket changes', async () => {
     (mockLabService.prototype.queryByLaboratoryId as jest.Mock).mockResolvedValue({
       OrganizationId: ORG_ID,

--- a/packages/front-end/src/app/components/EGFormLabDetails.vue
+++ b/packages/front-end/src/app/components/EGFormLabDetails.vue
@@ -13,6 +13,7 @@
     NetworkingModeSchema,
     VpcConfigurationNameSchema,
     LlmModelIdSchema,
+    LlmApiKeySchema,
     LabDetailsFormModeEnum,
     LabDetailsFormMode,
   } from '@FE/types/labs';
@@ -407,6 +408,25 @@
       default:
         return '';
     }
+  }
+
+  /**
+   * A saved API key is scoped to whichever provider it was entered for, so it can't cover a
+   * provider the admin has since switched to — a fresh key is required in that case even
+   * though `hasSavedApiKey` is still true for the (now-stale) key from the original provider.
+   */
+  function isLlmApiKeyRequired(
+    currentProvider: string | undefined,
+    originalProvider: string | undefined,
+    hasSavedApiKey: boolean | undefined,
+  ): boolean {
+    if (formMode.value === LabDetailsFormModeEnum.enum.Create) {
+      return true;
+    }
+    if (currentProvider !== originalProvider) {
+      return true;
+    }
+    return !hasSavedApiKey;
   }
 
   /**
@@ -858,6 +878,20 @@
       maybeAddFieldValidationErrors(errors, LlmModelIdSchema, 'SeqeraLlmModelId', state.SeqeraLlmModelId);
     }
 
+    // openai/anthropic are BYOK: an API key is required unless one is already saved
+    // for the currently-selected provider specifically (see isLlmApiKeyRequired).
+    if (state.HealthOmicsLlmProvider === 'openai' || state.HealthOmicsLlmProvider === 'anthropic') {
+      if (
+        isLlmApiKeyRequired(
+          state.HealthOmicsLlmProvider,
+          uneditedLabDetails.value?.HealthOmicsLlmProvider,
+          uneditedLabDetails.value?.HasHealthOmicsLlmApiKey,
+        )
+      ) {
+        maybeAddFieldValidationErrors(errors, LlmApiKeySchema, 'HealthOmicsLlmApiKey', state.HealthOmicsLlmApiKey);
+      }
+    }
+
     if (notifyOnLabRunsEnabled.value && additionalEmailsError.value) {
       errors.push({ path: 'NotifyOnLabRunsAdditionalEmailsInput', message: additionalEmailsError.value });
     }
@@ -983,6 +1017,21 @@
       validate(newState);
     },
     { deep: true },
+  );
+
+  // Model ID and API Key are provider-specific and must not silently carry over when the
+  // admin switches HealthOmics LLM provider. Skipped when the new value matches the
+  // originally-saved provider — e.g. the initial load, or Cancel resetting the form —
+  // since state.HealthOmicsLlmModelId/ApiKey were just (re)set to the correct saved values.
+  watch(
+    () => state.value.HealthOmicsLlmProvider,
+    (newProvider) => {
+      if (newProvider === uneditedLabDetails.value?.HealthOmicsLlmProvider) {
+        return;
+      }
+      state.value.HealthOmicsLlmModelId = '';
+      state.value.HealthOmicsLlmApiKey = '';
+    },
   );
 
   // The four per-user notification controls aren't part of `state`, so they need their own
@@ -1379,10 +1428,20 @@
               name="HealthOmicsLlmApiKey"
               eager-validation
               :required="
-                formMode === LabDetailsFormModeEnum.enum.Create || !uneditedLabDetails?.HasHealthOmicsLlmApiKey
+                isLlmApiKeyRequired(
+                  state.HealthOmicsLlmProvider,
+                  uneditedLabDetails?.HealthOmicsLlmProvider,
+                  uneditedLabDetails?.HasHealthOmicsLlmApiKey,
+                )
               "
             >
-              <div v-if="uneditedLabDetails?.HasHealthOmicsLlmApiKey" class="mb-2 flex items-center gap-2">
+              <div
+                v-if="
+                  uneditedLabDetails?.HasHealthOmicsLlmApiKey &&
+                  state.HealthOmicsLlmProvider === uneditedLabDetails?.HealthOmicsLlmProvider
+                "
+                class="mb-2 flex items-center gap-2"
+              >
                 <UBadge size="sm" class="bg-alert-danger-muted text-alert-danger rounded-xl border-0 ring-0">
                   KEY SAVED
                 </UBadge>


### PR DESCRIPTION
## Title*
Fix HealthOmics AI Failure Analysis LLM key/model reuse across providers

## Type of Change*
- [x] Bug fix

## Description
The API key and Model ID for AI Failure Analysis (HealthOmics) were single fields shared across all LLM providers (bedrock/openai/anthropic) rather than scoped per-provider. Switching the provider dropdown (e.g. OpenAI → Anthropic) silently reused the previous provider's saved key and model, with no validation error — only failing downstream at the actual provider API call.

Root cause: `HasHealthOmicsLlmApiKey` only tracks whether *any* key was ever saved for the integration, not *which provider* it belongs to, and the API Key field's `:required` attribute was purely cosmetic (Nuxt UI's `required` prop just adds an asterisk — `validate()` never actually checked for presence).

**Fix:**
- Front-end (`EGFormLabDetails.vue`): clears Model ID/API Key when the provider changes away from the originally-saved one; `validate()` now enforces the key requirement via the previously-unused `LlmApiKeySchema`; hides the "KEY SAVED" badge once it no longer applies to the newly-selected provider.
- Back-end (`update-laboratory.lambda.ts`): rejects the save with a 400 (`InvalidRequestError`) when `HealthOmicsLlmProvider` changes to `openai`/`anthropic` without a new `HealthOmicsLlmApiKey` in the request — closes the same gap for direct API calls, not just the UI.

Scoped to HealthOmics only. Seqera has the identical pattern but is being soft-deprecated, so left as-is there.

## Testing*
- Added 4 new unit tests to `update-laboratory.lambda.test.ts` (TDD: written failing first, confirmed the failure, then implemented the fix) covering: provider changed without new key → 400; provider changed with new key → 200 + SSM write; provider unchanged, no new key → 200, key preserved; switch to `bedrock` → 200, no key required.
- Full suite results: back-end 813/813, shared-lib 156/156 (incl. `openapi-guard.test.ts`), front-end 129/129 — all passing, lint clean.
- Manual test steps documented in `TESTING.md` (workspace root, not yet executed by a human).

## Impact
No schema or storage shape changes. No new dependencies. Only affects the HealthOmics AI Failure Analysis provider-switch flow.

## Additional Information
None.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [x] Documentation has been updated accordingly (TESTING.md).
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.
