### PR TITLE
fix: stop spurious Seqera error toast when cancelling a run

### DIFF
--- a/packages/front-end/src/app/components/EGLabView.vue
+++ b/packages/front-end/src/app/components/EGLabView.vue
@@ -264,6 +264,15 @@
 
   type LaboratoryRunTableItem = LaboratoryRun & { lastUpdated: string; searchIndex: string };
 
+  const TERMINAL_STATUSES = ['FAILED', 'SUCCEEDED', 'CANCELLED', 'COMPLETED', 'DELETED'];
+
+  /**
+   * Runs cancelled during this session. Cancelling only signals the compute platform; the
+   * LaboratoryRun record is updated later by the status check pipeline, so these are shown as
+   * cancelled until the server reports a terminal status of its own.
+   */
+  const locallyCancelledRunIds = ref<Set<string>>(new Set());
+
   const runsTableColumns = [
     { key: 'RunName', label: 'Run Name', sortable: true },
     { key: 'WorkflowName', label: 'Workflow name', sortable: true },
@@ -327,11 +336,17 @@
   }
 
   const filteredRunsTableItems = computed<LaboratoryRunTableItem[]>(() => {
-    if (!runsSearchQuery.value.trim()) {
-      return runsTableItems.value;
-    }
+    const items = !runsSearchQuery.value.trim()
+      ? runsTableItems.value
+      : runsTableItems.value.filter((run) => matchesRunSearch(run, runsSearchQuery.value));
 
-    return runsTableItems.value.filter((run) => matchesRunSearch(run, runsSearchQuery.value));
+    // Display-only override. Status checks read the untouched runsTableItems, so the server keeps
+    // being polled for the run's real status.
+    return items.map((run) =>
+      locallyCancelledRunIds.value.has(run.RunId) && !TERMINAL_STATUSES.includes(run.Status)
+        ? { ...run, Status: 'CANCELLED' }
+        : run,
+    );
   });
 
   // fetch the runs any time any of the inputs change; apply "My runs only" client-side
@@ -664,7 +679,6 @@
   }
 
   async function requestLabRunStatusCheck() {
-    const TERMINAL_STATUSES = ['FAILED', 'SUCCEEDED', 'CANCELLED', 'COMPLETED', 'DELETED'];
     try {
       const nonTerminalRunIds = runsTableItems.value
         .filter((run) => !TERMINAL_STATUSES.includes(run.Status))
@@ -778,6 +792,9 @@
         uiStore.setRequestPending('cancelOmicsRun');
         await $api.omicsRuns.cancelWorkflowRun(props.labId, externalRunId);
       }
+
+      locallyCancelledRunIds.value = new Set(locallyCancelledRunIds.value).add(runId);
+
       // Analytics: run cancelled (platform + status only; no run name / id).
       useAnalytics().track('run_cancelled', {
         platform: runPlatform === 'Seqera Cloud' ? 'seqera' : 'omics',

--- a/packages/front-end/src/app/components/EGLabView.vue
+++ b/packages/front-end/src/app/components/EGLabView.vue
@@ -791,8 +791,14 @@
     uiStore.setRequestComplete('cancelSeqeraRun');
     uiStore.setRequestComplete('cancelOmicsRun');
 
-    await getSeqeraRuns();
-    await getOmicsRuns();
+    // Only refresh a platform the lab can actually reach; otherwise the fetch fails and toasts a
+    // misleading error about the platform the user never touched.
+    if (lab.value?.NextFlowTowerEnabled && !missingPAT.value) {
+      await getSeqeraRuns();
+    }
+    if (lab.value?.AwsHealthOmicsEnabled) {
+      await getOmicsRuns();
+    }
   }
 
   async function handleDetailsUpdated() {


### PR DESCRIPTION
## fix: stop spurious Seqera error toast when cancelling a run

## Type of Change*
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
QA reported that cancelling a HealthOmics run shows the error toast
"Failed to load Seqera runs. Please refresh." even though no Seqera run is
involved.
The cancel itself succeeds. The error comes from the refresh that runs
immediately afterwards: `handleCancelDialogAction` unconditionally called both
`getSeqeraRuns()` and `getOmicsRuns()`, regardless of the cancelled run's
platform or whether the lab can reach either platform. On a lab that has
`NextFlowTowerEnabled` set but no Personal Access Token stored, the Seqera fetch
hits `GET /nf-tower/workflow/list-workflows`, which throws
`LaboratoryAccessTokenUnavailableError` (or `MissingNextFlowTowerAccessError`
when the flag is off). `runStore.loadSeqeraRunsForLab` catches that and toasts.
This is not a regression from #916. Those two refresh calls have been unguarded
since the lab view was extracted into a component (904265a8). Previously the
cancel request itself failed too, so the Seqera toast appeared alongside
"Failed to cancel run" and blended in. Now that cancel works, it's the only
error left on screen, which made it look new.
The fix gates each refresh on the lab's capability flags, reusing the same
conditions this component already uses to decide which tabs to show and which
data to fetch in the `watch(lab)` handler. The Omics refresh is gated
symmetrically because the mirror-image bug exists: cancelling a Seqera run in a
Seqera-only lab would toast "Failed to load Omics runs. Please refresh."

## Testing*
1. On a lab with HealthOmics enabled and Seqera enabled but **no** PAT, start a
   run, cancel it, and confirm no Seqera error toast appears.
2. On a lab with both platforms fully configured, cancel a run on each platform
   and confirm both still cancel and refresh correctly.

## Impact
Front-end only, scoped to the post-cancel refresh path. Removes one HTTP request
on labs that can't serve it. No API, schema, or infrastructure changes.

## Additional Information
[Any additional information that reviewers should be aware of.]

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [x] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.