### PR TITLE
fix: (egv-278) Preserve HealthOmics AI Failure Analysis Model ID/API Key when switching providers

### DIFF
--- a/packages/front-end/src/app/components/EGFormLabDetails.vue
+++ b/packages/front-end/src/app/components/EGFormLabDetails.vue
@@ -131,6 +131,11 @@
   const isEditingNextFlowTowerAccessToken = ref(false);
   const isEditingGitHubAccessToken = ref(false);
 
+  // Holds unsaved Model ID / API Key input per HealthOmics LLM provider for the duration of the
+  // current edit session, so switching the provider dropdown back and forth doesn't discard what
+  // the admin already typed for a provider. Cleared on Cancel; never persisted or submitted.
+  const healthOmicsLlmProviderDrafts: Ref<Record<string, { modelId: string; apiKey: string }>> = ref({});
+
   // BYOK provider dropdown options + per-provider hints/placeholders for the
   // Model ID input. The leading option lets users reset back to "no provider".
   // Its value is '' rather than null: USelect renders a native <select>, whose
@@ -579,6 +584,7 @@
    */
   function handleCancelEdit() {
     state.value = { ...uneditedLabDetails.value! };
+    healthOmicsLlmProviderDrafts.value = {};
     notifyOnOwnRunsEnabled.value = uneditedNotifyOnOwnRunsEnabled.value;
     notifyOnLabRunsEnabled.value = uneditedNotifyOnLabRunsEnabled.value;
     notificationEventFilter.value = uneditedNotificationEventFilter.value;
@@ -1023,14 +1029,25 @@
   // admin switches HealthOmics LLM provider. Skipped when the new value matches the
   // originally-saved provider — e.g. the initial load, or Cancel resetting the form —
   // since state.HealthOmicsLlmModelId/ApiKey were just (re)set to the correct saved values.
+  //
+  // Otherwise, the values just navigated away from are stashed in healthOmicsLlmProviderDrafts
+  // keyed by the old provider, and restored if the admin switches back to it later in the same
+  // edit session — so re-selecting a provider doesn't wipe out what was already typed for it.
   watch(
     () => state.value.HealthOmicsLlmProvider,
-    (newProvider) => {
+    (newProvider, oldProvider) => {
       if (newProvider === uneditedLabDetails.value?.HealthOmicsLlmProvider) {
         return;
       }
-      state.value.HealthOmicsLlmModelId = '';
-      state.value.HealthOmicsLlmApiKey = '';
+      if (oldProvider) {
+        healthOmicsLlmProviderDrafts.value[oldProvider] = {
+          modelId: state.value.HealthOmicsLlmModelId,
+          apiKey: state.value.HealthOmicsLlmApiKey,
+        };
+      }
+      const draft = newProvider ? healthOmicsLlmProviderDrafts.value[newProvider] : undefined;
+      state.value.HealthOmicsLlmModelId = draft?.modelId ?? '';
+      state.value.HealthOmicsLlmApiKey = draft?.apiKey ?? '';
     },
   );
 


### PR DESCRIPTION
## Title*
Preserve HealthOmics AI Failure Analysis Model ID/API Key when switching providers

## Type of Change*
- [x] Bug fix

## Description
Follow-up to #921. Switching the HealthOmics LLM provider dropdown away from and back to a provider whose Model ID/API Key had already been typed (but not yet saved) cleared those fields, because the field-reset watcher in `EGFormLabDetails.vue` unconditionally blanked both on every provider change, except when returning to the originally-saved provider.

This doesn't allow bad data to be saved — `validate()` still requires the field per the #921 fix — but it's confusing: the admin types a Model ID, tabs through providers, comes back, and finds it gone.

**Fix:** `EGFormLabDetails.vue` now stashes the in-progress Model ID/API Key per provider in a session-scoped draft cache (`healthOmicsLlmProviderDrafts`) as the provider changes, and restores from that cache when switching back to a provider visited earlier in the same edit. The cache is cleared on Cancel so it never leaks into a later edit session. Save-time validation is untouched.

## Testing*
- Front-end: `pnpm lint` and `pnpm test` (129/129) pass.
- Back-end/shared-lib: full `pnpm test` suite (813/813 back-end, unaffected) passes via pre-commit hook.
- No dedicated unit test exists for this component (large form with no existing test suite for it); verified by tracing the reactivity flow. Recommend a manual pass before merge: configure a Model ID for provider A, switch to B, switch back to A, confirm A's Model ID is restored.

## Impact
Front-end only, scoped to the HealthOmics LLM provider dropdown in Lab Settings. No schema, storage, or API changes.

## Additional Information
None.

## Checklist*
- [x] No new errors or warnings have been introduced.
- [x] All tests pass successfully and new tests added as necessary.
- [ ] Documentation has been updated accordingly.
- [x] Code adheres to the coding and style guidelines of the project.
- [x] Code has been commented in particularly hard-to-understand areas.
