### PR TITLE
docs: distinguish failed-update from failed-create when recovering a deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,10 +32,17 @@ Hotfix for v1.5. **Tier 1** upgrade — no DynamoDB, schema, or configuration ch
 No schema change, no data migration, and no backfill. Organization logo URLs persisted by v1.5 keep resolving: only the
 host is rewritten at read time, and the object stays at its original key.
 
-> **If your v1.5 deploy failed and rolled back, you cannot deploy v1.5.1 over it.** A rolled-back stack can only be
-> deleted, and deleting it leaves the `{namePrefix}-*` DynamoDB tables behind with deletion protection enabled — the
-> next deploy then fails with `ResourceInUseException: Table already exists` until they are dealt with. See
-> [§7.1 Recovering from a failed deploy](./docs/deployment/upgrading.md#71-recovering-from-a-failed-deploy).
+**If your v1.5 deploy failed and rolled back**, check the stack status before doing anything — it decides whether any
+cleanup is needed at all:
+
+- `UPDATE_ROLLBACK_COMPLETE` — an update failed on a deployment that already existed. The stack is intact and updatable,
+  so **deploy v1.5.1 straight over it; nothing needs deleting.** This is the usual case when upgrading.
+- `ROLLBACK_COMPLETE` — the stack's first creation failed. CloudFormation cannot update this state, so the stack must be
+  deleted first, which leaves the `{namePrefix}-*` DynamoDB tables behind with deletion protection enabled.
+
+See [§7.1 Recovering from a failed deploy](./docs/deployment/upgrading.md#71-recovering-from-a-failed-deploy) for both
+paths, including the one case that can still block a redeploy: a table the failed release _added_ is retained rather
+than deleted during a rollback, so it can be left orphaned and must be removed before deploying again.
 
 ## [v1.5] — Back-End API stack split
 

--- a/docs/deployment/upgrading.md
+++ b/docs/deployment/upgrading.md
@@ -249,17 +249,75 @@ minutes across all Lambda log groups. No `ERROR`-level entries should appear aft
 ### 7.1 Recovering from a failed deploy
 
 The table above covers rolling **back** a release that deployed successfully. This section covers the different case: a
-deploy that **never completed** and left CloudFormation mid-rollback. You cannot deploy the next version over it — two
-things block you, in order.
+deploy that **never completed** and left CloudFormation mid-rollback.
 
-**1. A rolled-back stack must be deleted, not updated.** A stack in `ROLLBACK_COMPLETE` cannot be updated by
-CloudFormation at all. Find the affected root stacks and delete those; nested stacks go with their parent:
+**Start by reading the stack status. It decides everything, and two of the statuses look alike but mean opposite
+things.**
 
 ```bash
 aws cloudformation list-stacks \
   --query "StackSummaries[?starts_with(StackName,'<namePrefix>') && StackStatus!='DELETE_COMPLETE'].[StackName,StackStatus]" \
   --output table
+```
 
+| Status                     | What happened                             | What to do                                                      |
+| -------------------------- | ----------------------------------------- | --------------------------------------------------------------- |
+| `UPDATE_ROLLBACK_COMPLETE` | An **update** failed on an existing stack | [§7.1.1](#711-a-failed-update) — just redeploy                  |
+| `UPDATE_ROLLBACK_FAILED`   | The rollback itself could not finish      | [§7.1.2](#712-a-rollback-that-did-not-finish) — resume it first |
+| `ROLLBACK_COMPLETE`        | The stack's **first creation** failed     | [§7.1.3](#713-a-failed-first-creation) — delete and redeploy    |
+
+Only `ROLLBACK_COMPLETE` requires deletion. If your deployment already existed before the upgrade, you are almost
+certainly in the first case, and **no cleanup is needed** — do not delete anything.
+
+#### 7.1.1 A failed update
+
+`UPDATE_ROLLBACK_COMPLETE` is a stable, updatable state. CloudFormation rolled the failed update back and your stack is
+intact and running the previous version. Fix the cause, then deploy again as normal:
+
+```bash
+git fetch --tags && git checkout <target-tag>
+pnpm install
+pnpm run build-and-deploy
+```
+
+**One caveat if the failed release added new DynamoDB tables.** Tables carry `RemovalPolicy.RETAIN`, so any table the
+update created before failing is _released_ rather than deleted during the rollback — the physical table survives, but
+the stack no longer tracks it. The next deploy then fails with `ResourceInUseException: Table already exists` for those
+tables only. Check the ones the release introduces:
+
+```bash
+aws cloudformation describe-stack-resources --physical-resource-id <namePrefix>-<new>-table \
+  --query "StackResources[?ResourceType=='AWS::DynamoDB::Table'].[StackName,LogicalResourceId]" --output text
+```
+
+A stack name means it is still tracked — do nothing. An error means it is orphaned. Such a table was created minutes
+before the rollback and is empty, so deleting that specific table is safe; confirm with
+`aws dynamodb scan --table-name <table> --select COUNT` before you do. **Never** apply this to a table that predates the
+failed release.
+
+#### 7.1.2 A rollback that did not finish
+
+`UPDATE_ROLLBACK_FAILED` means CloudFormation could not complete the rollback, usually because a resource would not
+delete. The stack accepts no updates until the rollback finishes:
+
+```bash
+aws cloudformation continue-update-rollback --stack-name <stack>
+
+# If the same resource keeps blocking it, skip that resource and reconcile it afterwards:
+aws cloudformation continue-update-rollback --stack-name <stack> \
+  --resources-to-skip <LogicalResourceId>
+```
+
+Once it reaches `UPDATE_ROLLBACK_COMPLETE`, follow §7.1.1.
+
+#### 7.1.3 A failed first creation
+
+`ROLLBACK_COMPLETE` only occurs when a stack's **initial creation** failed. CloudFormation cannot update a stack in this
+state at all — it must be deleted and recreated. This is the only case that requires deletion.
+
+Find the affected root stacks and delete those; nested stacks go with their parent:
+
+```bash
 aws cloudformation delete-stack --stack-name <namePrefix>-easy-genomics-api-stack
 aws cloudformation wait stack-delete-complete --stack-name <namePrefix>-easy-genomics-api-stack
 ```
@@ -267,7 +325,7 @@ aws cloudformation wait stack-delete-complete --stack-name <namePrefix>-easy-gen
 Delete in dependency order: `*-easy-genomics-api-stack` imports Cognito and KMS values from `*-main-back-end-stack`, so
 the api stack goes first. Leave the shared `CDKToolkit` bootstrap stack alone.
 
-**2. Deleting the stack orphans the DynamoDB tables.** Tables are provisioned with `RemovalPolicy.RETAIN` **and**
+**Deleting the stack orphans the DynamoDB tables.** Tables are provisioned with `RemovalPolicy.RETAIN` **and**
 `deletionProtection: true` unconditionally — deliberate data protection that does **not** depend on `env-type`, so it
 applies to `dev` environments too. They survive the stack deletion (reported as `DELETE_SKIPPED` in the event log) and
 keep their explicit names, so the next deploy fails with `ResourceInUseException: Table already exists`.


### PR DESCRIPTION
## Title*

Distinguish a failed update from a failed creation when recovering a deploy

## Type of Change*

- [ ] New feature
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description

`docs/deployment/upgrading.md` §7.1 and the v1.5.1 `CHANGELOG.md` Migration note — both added in #929 — tell operators
that a rolled-back stack "can only be deleted". That is true only of `ROLLBACK_COMPLETE`, the status CloudFormation
produces when a stack's **first creation** fails. An upgrade that fails on a deployment that already exists produces
`UPDATE_ROLLBACK_COMPLETE`, which is a stable, updatable state: the correct action is to deploy again, with nothing to
delete.

I wrote that guidance from the deploy verification for #929, which ran against a brand-new throwaway environment. Only
the create-failure case was ever observed, and it was generalised to every failed deploy.

**This was caught in the field, not in review.** A customer whose v1.5 upgrade failed followed the flow and was asked to
delete their stack and DynamoDB tables. Their environment turned out to be `UPDATE_ROLLBACK_COMPLETE` with 7
laboratories, 3 organizations, 21 users and 19 laboratory runs in it. Nothing needed deleting, and the deletion would
have been unrecoverable without a backup.

Changes:

- **§7.1 now triages on stack status first**, before any action, and routes to one of three paths:
  - `UPDATE_ROLLBACK_COMPLETE` → §7.1.1, redeploy, no cleanup.
  - `UPDATE_ROLLBACK_FAILED` → §7.1.2, `continue-update-rollback` first. **This state was not documented at all** and is
    the one that genuinely blocks further updates.
  - `ROLLBACK_COMPLETE` → §7.1.3, the existing delete-and-recreate path, now scoped to the only case that needs it.
- **§7.1.1 records the one thing that can still block a redeploy after a failed update:** a DynamoDB table the release
  *added* carries `RemovalPolicy.RETAIN`, so the rollback releases rather than deletes it and the stack stops tracking
  it. The next deploy then fails with `ResourceInUseException` for that table alone. Includes how to tell a genuinely
  orphaned table from one that predates the release, and to confirm it is empty before removing it.
- **The CHANGELOG note leads with the safe case** — "deploy v1.5.1 straight over it; nothing needs deleting" — rather
  than the destructive one.

## Testing\*

Documentation only; no code paths change and no tests apply.

Verified: prettier clean under the repo config, all four in-page anchors (`#71-…`, `#711-…`, `#712-…`, `#713-…`) resolve
to real headings, and the phrases "can only be deleted" / "must be deleted, not updated" no longer appear in either
file.

The behavioural claims come from observed CloudFormation states rather than assumption — `ROLLBACK_COMPLETE` from our
own v1.5 reproduction in the DEPT dev account, and `UPDATE_ROLLBACK_COMPLETE` from the customer environment that
prompted this.

## Impact

Documentation only. No code, infrastructure, dependency or configuration changes.

The corrected text reaches `main` with the next release. Until then the incorrect version remains live on `main` and is
what the v1.5.1 release notes link to. The affected customer has been advised directly in the meantime. If we would
rather not wait, this same commit can also go to `main` as a separate docs-only PR.

## Additional Information

Worth noting for review: §7.1 was itself written to close a gap found during the v1.5.1 deploy test, so this is a fix to
a fix. The underlying lesson is that recovery guidance derived from a greenfield reproduction does not automatically
hold for an environment with history — the same reasoning error would apply to any future runbook written the same way.

## Checklist\*

- [x] No new errors or warnings have been introduced. _(Markdown only. The single pre-existing `import/order` warning
      from the pre-commit hook is unrelated to this branch.)_
- [ ] All tests pass successfully and new tests added as necessary. _(N/A — documentation only. The pre-commit hook ran
      the back-end suite and it passed, but nothing here is covered by tests.)_
- [x] Documentation has been updated accordingly. _(This change is the documentation update.)_
- [x] Code adheres to the coding and style guidelines of the project. _(Prettier-formatted with the repo config.)_
- [ ] Code has been commented in particularly hard-to-understand areas. _(N/A — no code.)_
